### PR TITLE
Sync recording mode page navigation with main viewer

### DIFF
--- a/src/vue/App.vue
+++ b/src/vue/App.vue
@@ -162,7 +162,7 @@ async function toggleRecordingMode() {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       stream.getTracks().forEach((track) => track.stop()); // Release immediately, we'll request again when recording
       recordingMode.value = true;
-      currentPage.value = 0;
+      // Keep current page position instead of resetting to 0
       recordedAudios.value = new Map();
       editedTexts.value = new Map();
     } catch (e) {
@@ -499,6 +499,7 @@ function discardRecordings() {
         </div>
 
         <MulmoViewer
+          :key="recordingMode ? `recording-${currentPage}` : 'viewer'"
           :data-set="viewData"
           :base-path="basePath"
           :init-page="currentPage"


### PR DESCRIPTION
## 概要
Recording modeのページナビゲーションとメインビューアを同期させるようにしました。

<img width="793" height="686" alt="CleanShot 2026-01-13 at 15 06 39" src="https://github.com/user-attachments/assets/93b325bb-4177-4168-8d91-418dc527e36a" />

## 変更内容
### ページ同期
- Recording mode開始時に現在のページ位置を維持するように変更（以前は常にページ0にリセット）
- Recording panelのPrev/NextボタンでMulmoViewerのページも連動して切り替わるように修正

### 技術的な変更
- toggleRecordingMode()からcurrentPage.value = 0のリセット処理を削除
- MulmoViewerコンポーネントに動的key属性を追加し、Recording mode時のページ変更を反映

### 変更ファイル
- src/vue/App.vue

### テスト方法
- yarn previewでプレビューサーバーを起動
- メインビューアでページ2以降に移動
- 「Record Audio」ボタンをクリック
- Recording panelが現在のページを表示していることを確認
- Recording panelのPrev/Nextでメインビューアも連動することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recording mode now preserves your current page position instead of resetting to the beginning, improving workflow continuity during recording sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->