### PR TITLE
Save recorded audio as WebM and keep original TTS audio

### DIFF
--- a/src/utils/audio-save.ts
+++ b/src/utils/audio-save.ts
@@ -118,25 +118,19 @@ export function saveAudio(outputDir: string, request: SaveAudioRequest): SaveAud
       };
     }
 
-    // Generate audio filename
-    const audioFile = `${beatIndex + 1}_${langKey}.mp3`;
+    // Generate audio filename (save as WebM for reference/debugging)
+    const audioFile = `${beatIndex + 1}_${langKey}_recorded.webm`;
     const audioPath = path.join(bundleDir, audioFile);
 
-    // Decode and save audio file
+    // Decode and save audio file as WebM
     const audioBuffer = Buffer.from(audioBase64, "base64");
     fs.writeFileSync(audioPath, audioBuffer);
 
-    // Ensure audioSources and multiLinguals exist
+    // Ensure multiLinguals exist (do NOT update audioSources - keep original TTS audio)
     const beat = viewData.beats[beatIndex];
-    if (!beat.audioSources) {
-      beat.audioSources = {};
-    }
     if (!beat.multiLinguals) {
       beat.multiLinguals = {};
     }
-
-    // Update mulmo_view.json
-    beat.audioSources[langKey] = audioFile;
 
     // Update text if provided
     if (text !== undefined) {


### PR DESCRIPTION
## 概要
録音機能の動作を修正しました。
- 録音音声をWebM形式で保存するように変更（1_ja_recorded.webm）
- audioSourcesを更新しないように変更（元のTTS音声を維持）
- テキストのみmultiLingualsに保存

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio file preservation to prevent unwanted overwrites of original TTS audio
  * Updated audio format from MP3 to WebM for better quality retention
  * Enhanced multilingual text handling with improved fallback behavior when text updates are not provided

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->