### PR TITLE
Refine Edit Mode UI and unify save-beat-text endpoint

### DIFF
--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -5,13 +5,11 @@ import * as fs from "fs";
 import * as path from "path";
 import dotenv from "dotenv";
 import {
-  saveAudio,
+  saveBeatText,
   transcribeAudio,
-  saveTextOnly,
   parseRequestBody,
-  type SaveAudioRequest,
+  type SaveBeatTextRequest,
   type TranscribeRequest,
-  type SaveTextRequest,
 } from "../utils/audio-save";
 import { findBundles, getMimeType, isValidFile, createFileStream } from "../utils/bundle-server";
 
@@ -64,14 +62,14 @@ export function startPreviewServer(port: number = DEFAULT_PORT): void {
     }
 
     // API endpoint for saving recorded audio
-    if (pathname === "/api/save-audio" && req.method === "POST") {
-      const body = await parseRequestBody<SaveAudioRequest>(req);
+    if (pathname === "/api/save-beat-text" && req.method === "POST") {
+      const body = await parseRequestBody<SaveBeatTextRequest>(req);
       if (!body) {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ success: false, error: "Invalid request body" }));
         return;
       }
-      const result = saveAudio(outputDir, body);
+      const result = saveBeatText(outputDir, body);
       res.writeHead(result.success ? 200 : 400, { "Content-Type": "application/json" });
       res.end(JSON.stringify(result));
       return;
@@ -86,20 +84,6 @@ export function startPreviewServer(port: number = DEFAULT_PORT): void {
         return;
       }
       const result = await transcribeAudio(body);
-      res.writeHead(result.success ? 200 : 400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(result));
-      return;
-    }
-
-    // API endpoint for saving text only
-    if (pathname === "/api/save-text" && req.method === "POST") {
-      const body = await parseRequestBody<SaveTextRequest>(req);
-      if (!body) {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ success: false, error: "Invalid request body" }));
-        return;
-      }
-      const result = saveTextOnly(outputDir, body);
       res.writeHead(result.success ? 200 : 400, { "Content-Type": "application/json" });
       res.end(JSON.stringify(result));
       return;

--- a/src/utils/audio-save.ts
+++ b/src/utils/audio-save.ts
@@ -16,29 +16,17 @@ export interface TranscribeResult {
   error?: string;
 }
 
-export interface SaveAudioRequest {
+export interface SaveBeatTextRequest {
   bundlePath: string; // e.g., "GraphAI/mulmo_script"
   beatIndex: number;
   langKey: string; // e.g., "recorded", "ja-custom"
-  audioBase64: string; // base64 encoded audio data
-  text?: string; // transcribed/edited text to save
+  text: string; // transcribed/edited text to save
+  audioBase64?: string; // base64 encoded audio data (optional)
 }
 
-export interface SaveAudioResult {
+export interface SaveBeatTextResult {
   success: boolean;
   audioFile?: string;
-  error?: string;
-}
-
-export interface SaveTextRequest {
-  bundlePath: string;
-  beatIndex: number;
-  langKey: string;
-  text: string;
-}
-
-export interface SaveTextResult {
-  success: boolean;
   error?: string;
 }
 
@@ -104,7 +92,7 @@ function findScriptsDir(outputDir: string, bundlePath: string): string | null {
   return null;
 }
 
-export function saveAudio(outputDir: string, request: SaveAudioRequest): SaveAudioResult {
+export function saveBeatText(outputDir: string, request: SaveBeatTextRequest): SaveBeatTextResult {
   try {
     const { bundlePath, beatIndex, langKey, audioBase64, text } = request;
 
@@ -131,13 +119,16 @@ export function saveAudio(outputDir: string, request: SaveAudioRequest): SaveAud
       };
     }
 
-    // Generate audio filename (save as WebM for reference/debugging)
-    const audioFile = `${beatIndex + 1}_${langKey}_recorded.webm`;
-    const audioPath = path.join(bundleDir, audioFile);
+    let audioFile: string | undefined;
+    if (audioBase64) {
+      // Generate audio filename (save as WebM for reference/debugging)
+      audioFile = `${beatIndex + 1}_${langKey}_recorded.webm`;
+      const audioPath = path.join(bundleDir, audioFile);
 
-    // Decode and save audio file as WebM
-    const audioBuffer = Buffer.from(audioBase64, "base64");
-    fs.writeFileSync(audioPath, audioBuffer);
+      // Decode and save audio file as WebM
+      const audioBuffer = Buffer.from(audioBase64, "base64");
+      fs.writeFileSync(audioPath, audioBuffer);
+    }
 
     // Ensure multiLinguals exist (do NOT update audioSources - keep original TTS audio)
     const beat = viewData.beats[beatIndex];
@@ -145,79 +136,6 @@ export function saveAudio(outputDir: string, request: SaveAudioRequest): SaveAud
       beat.multiLinguals = {};
     }
 
-    // Update text if provided
-    if (text !== undefined) {
-      beat.multiLinguals[langKey] = text;
-    } else if (!beat.multiLinguals[langKey]) {
-      // Use original text as placeholder if no text provided
-      const originalLang = viewData.lang || "en";
-      beat.multiLinguals[langKey] = beat.multiLinguals[originalLang] || beat.text || "";
-    }
-
-    // Save updated mulmo_view.json
-    fs.writeFileSync(viewPath, JSON.stringify(viewData, null, 2));
-
-    // Also update mulmo_script.json if it exists in scripts directory
-    const scriptsDir = findScriptsDir(outputDir, bundlePath);
-    if (scriptsDir && text !== undefined) {
-      const scriptPath = path.join(scriptsDir, "mulmo_script.json");
-      if (fs.existsSync(scriptPath)) {
-        try {
-          const scriptData: MulmoScript = JSON.parse(fs.readFileSync(scriptPath, "utf-8"));
-          if (scriptData.beats && scriptData.beats[beatIndex]) {
-            scriptData.beats[beatIndex].text = text;
-            fs.writeFileSync(scriptPath, JSON.stringify(scriptData, null, 2));
-          }
-        } catch {
-          // Ignore script update errors
-        }
-      }
-    }
-
-    return { success: true, audioFile };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
-
-// Save text only (no audio recording)
-export function saveTextOnly(outputDir: string, request: SaveTextRequest): SaveTextResult {
-  try {
-    const { bundlePath, beatIndex, langKey, text } = request;
-
-    // Validate bundle path
-    const bundleDir = path.join(outputDir, bundlePath);
-    if (!fs.existsSync(bundleDir)) {
-      return { success: false, error: `Bundle directory not found: ${bundlePath}` };
-    }
-
-    // Check mulmo_view.json exists
-    const viewPath = path.join(bundleDir, "mulmo_view.json");
-    if (!fs.existsSync(viewPath)) {
-      return { success: false, error: `mulmo_view.json not found in ${bundlePath}` };
-    }
-
-    // Read current mulmo_view.json
-    const viewData: MulmoViewerDataExtended = JSON.parse(fs.readFileSync(viewPath, "utf-8"));
-
-    // Validate beat index
-    if (beatIndex < 0 || beatIndex >= viewData.beats.length) {
-      return {
-        success: false,
-        error: `Invalid beat index: ${beatIndex}. Valid range: 0-${viewData.beats.length - 1}`,
-      };
-    }
-
-    // Ensure multiLinguals exist
-    const beat = viewData.beats[beatIndex];
-    if (!beat.multiLinguals) {
-      beat.multiLinguals = {};
-    }
-
-    // Update text
     beat.multiLinguals[langKey] = text;
 
     // Save updated mulmo_view.json
@@ -240,7 +158,7 @@ export function saveTextOnly(outputDir: string, request: SaveTextRequest): SaveT
       }
     }
 
-    return { success: true };
+    return { success: true, audioFile };
   } catch (error) {
     return {
       success: false,

--- a/src/vue/App.vue
+++ b/src/vue/App.vue
@@ -307,7 +307,7 @@ async function saveAllRecordings() {
         const blob = recordedAudios.value.get(beatIndex)!;
         const audioBase64 = await blobToBase64(blob);
 
-        const response = await fetch("/api/save-audio", {
+        const response = await fetch("/api/save-beat-text", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -324,7 +324,7 @@ async function saveAllRecordings() {
           throw new Error(result.error || `Failed to save beat ${beatIndex + 1}`);
         }
       } else {
-        const response = await fetch("/api/save-text", {
+        const response = await fetch("/api/save-beat-text", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 import * as path from "path";
 import dotenv from "dotenv";
-import { saveAudio, transcribeAudio, parseRequestBody } from "./src/utils/audio-save";
+import { saveBeatText, transcribeAudio, parseRequestBody } from "./src/utils/audio-save";
 import { findBundles, getMimeType, isValidFile, createFileStream } from "./src/utils/bundle-server";
 
 // Load .env file


### PR DESCRIPTION
## 概要
Edit Mode のUIを整理し、テキストのみでも保存できるようにしました。
それに伴い、saveAudio を saveBeatText に改名し、責務を「テキスト中心＋音声は任意」に合わせて整理しました。

<img width="1082" height="441" alt="CleanShot 2026-01-15 at 00 33 19" src="https://github.com/user-attachments/assets/888fe21f-8b1a-4cb9-87a1-54494907582e" />

<img width="1073" height="424" alt="CleanShot 2026-01-15 at 00 33 59" src="https://github.com/user-attachments/assets/69ffa877-7c6f-4f84-ab54-2a415000c6af" />

変更内容
- Record Mode を Edit Mode に名称変更
- 音声入力ボタンを “Voice Input” に変更
- Stop のアイコンを丸から四角に変更
- Voice Input / Stop / Transcribing のボタン幅を統一
- Edit Mode の表示を Edited 件数のみへ整理
- Save All の件数表示を Edited のみへ
- 保存APIを save-beat-text に統一（テキストを保存し、音声入力は任意で付与）
- Save All が録音なしの編集だけでも保存可能に

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio is now optional when saving beat edits; text can be saved independently.
  * "Recording mode" renamed to "Edit mode" with updated interface labels and button text.
  * Added edit count tracking to display the number of modified beats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->