### PR TITLE
Fix prev/next button vertical alignment to center on slide only

### DIFF
--- a/src/vue/App.vue
+++ b/src/vue/App.vue
@@ -554,9 +554,9 @@ function discardRecordings() {
         >
           <div class="w-full overflow-hidden">
             <div class="max-w-7xl mx-auto px-4">
-              <!-- スライド部分：ボタンはスライドメディアの縦中央に配置 -->
+              <!-- Slide section: buttons are vertically centered on slide media -->
               <div class="viewer-layout">
-                <!-- Prevボタン -->
+                <!-- Prev button -->
                 <button
                   class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 disabled:opacity-50"
                   :disabled="page === 0"
@@ -565,7 +565,7 @@ function discardRecordings() {
                   Prev
                 </button>
 
-                <!-- スライド画像/動画のみ（テキストなし） -->
+                <!-- Slide image/video only (no text) -->
                 <div class="slide-media-only">
                   <component
                     :is="MulmoPlayer"
@@ -574,7 +574,7 @@ function discardRecordings() {
                   />
                 </div>
 
-                <!-- Nextボタン -->
+                <!-- Next button -->
                 <button
                   class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 disabled:opacity-50"
                   :disabled="page >= pageCount - 1"
@@ -584,12 +584,12 @@ function discardRecordings() {
                 </button>
               </div>
 
-              <!-- テキスト部分（スライドと同じ幅） -->
+              <!-- Text section (same width as slide) -->
               <div class="viewer-layout">
-                <!-- 左側の空白（Prevボタンと同じ幅） -->
+                <!-- Left spacer (same width as Prev button) -->
                 <div class="nav-button-spacer"></div>
 
-                <!-- テキスト（スライドと同じ幅） -->
+                <!-- Text (same width as slide) -->
                 <div v-if="pageProps.text" class="slide-text-area">
                   <p class="text-lg leading-relaxed font-sans text-white">{{ pageProps.text }}</p>
                   <p
@@ -600,7 +600,7 @@ function discardRecordings() {
                   </p>
                 </div>
 
-                <!-- 右側の空白（Nextボタンと同じ幅） -->
+                <!-- Right spacer (same width as Next button) -->
                 <div class="nav-button-spacer"></div>
               </div>
             </div>
@@ -627,20 +627,20 @@ function discardRecordings() {
   margin-top: 1rem;
 }
 
-/* ビューワーレイアウト: ボタンとスライドを横並び、縦中央揃え */
+/* Viewer layout: buttons and slide in row, vertically centered */
 .viewer-layout {
   display: flex;
   align-items: center;
   gap: 1rem;
 }
 
-/* スライドメディア部分 */
+/* Slide media section */
 .slide-media-only {
   flex: 1;
   min-width: 0;
 }
 
-/* テキスト部分 */
+/* Text section */
 .slide-text-area {
   flex: 1;
   min-width: 0;
@@ -649,8 +649,8 @@ function discardRecordings() {
   padding: 1rem 1.5rem;
 }
 
-/* ボタンと同じ幅の空白 */
+/* Spacer with same width as nav buttons */
 .nav-button-spacer {
-  width: 52px; /* px-4 py-2 のボタンと同じ幅 */
+  width: 52px; /* same width as px-4 py-2 button */
 }
 </style>


### PR DESCRIPTION
## Summary
変更前
テキストの長さが変わると、ボタン位置が上下する

変更後
prev/next ボタンの縦方向の配置を、スライド画像の中央に固定するよう修正

<img width="1094" height="731" alt="CleanShot 2026-01-19 at 23 31 31" src="https://github.com/user-attachments/assets/4d5ccac7-f4b3-40f0-9143-904fce0209a0" />

## 変更内容
- MulmoViewer のスロット機能を使用してカスタムレイアウトを実装
- スライド画像とテキストを分離し、ボタンはスライド画像のみの縦中央に配置
- テキスト領域はスライドと同じ幅で、ボタンの下に独立して表示
- コンテンツの縦方向配置をブラウザ中央から上端に変更




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned viewer layout with integrated navigation controls for slide browsing.
  * Added text display area alongside slide content for enhanced viewing.
  * Enhanced recording mode with status indicators (language, beat, edit status) and error messaging.

* **Style**
  * Improved layout alignment and spacing for better visual consistency.
  * Updated styling for streamlined navigation and text editor components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->