### PR TITLE
Wrap MulmoViewer with theme variables and align layout to top

### DIFF
--- a/src/vue/App.vue
+++ b/src/vue/App.vue
@@ -434,7 +434,7 @@ function discardRecordings() {
       </div>
     </header>
 
-    <main class="flex-1 flex items-start justify-content p-4">
+    <main class="flex-1 flex items-start justify-center p-4">
       <div v-if="loading" class="text-center p-8 text-gray-400">Loading bundles...</div>
       <div v-else-if="error" class="text-center p-8 text-red-400">{{ error }}</div>
       <div v-else-if="bundles.length === 0" class="text-center p-8 text-gray-500">


### PR DESCRIPTION
## 変更内容
- 画面内の縦位置を items-start に変更して上寄せ配置

<img width="1071" height="629" alt="image" src="https://github.com/user-attachments/assets/327c3d33-bcd2-46be-a041-d257de246f29" />


- viewer 側の変更に対応 https://github.com/receptron/mulmocast-viewer/pull/28
```
<div class="text-white [--mulmo-text-bg:#1f2937] [--mulmo-text-secondary:#bbb]">
```
これに伴い以下の部分を削除

```
/* Override mulmocast-viewer text styles for better readability */
.text-gray-800 {
  color: #fff !important;
}
.text-gray-400 {
  color: #bbb !important;
}
.mt-4.px-6.py-4 {
  background: #1f2937;
  border-radius: 0.5rem;
  margin-top: 1rem;
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted vertical alignment of main content for improved layout.
  * Wrapped the viewer in a container to ensure consistent text color and theming.
  * Removed prior CSS overrides to restore cohesive visual styling.
  * Core viewer behavior and props remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->