### PR TITLE
feat: browser-safe markdown→MulmoScript transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,18 @@
   "license": "MIT",
   "author": "receptron",
   "type": "commonjs",
-  "main": "lib/cli.js",
+  "main": "lib/index.node.js",
+  "types": "lib/index.node.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.node.d.ts",
+      "default": "./lib/index.node.js"
+    },
+    "./browser": {
+      "types": "./lib/index.browser.d.ts",
+      "default": "./lib/index.browser.js"
+    }
+  },
   "bin": {
     "mulmo-slide": "./lib/cli.js"
   },

--- a/src/convert/markdown-transform.ts
+++ b/src/convert/markdown-transform.ts
@@ -1,0 +1,97 @@
+/**
+ * Markdown to MulmoScript Pure Transform
+ *
+ * Browser-safe pure functions for converting markdown strings to MulmoScript JSON.
+ * No Node.js dependencies (no fs, path, process, franc).
+ */
+
+import type { MulmoBeat } from "mulmocast";
+import type { SupportedLang } from "../utils/lang-common";
+import type { SeparatorMode } from "./markdown-plugins/types";
+import { splitIntoSlides, processMarkdown } from "./markdown-plugins/index";
+import { extractNotesFromSlide, extractMarkdownFromSlide } from "./markdown-utils-common";
+
+export interface MarkdownToMulmoScriptOptions {
+  lang?: SupportedLang;
+  separator?: SeparatorMode;
+  mermaid?: boolean;
+  directive?: boolean;
+  layout?: boolean;
+  style?: string;
+}
+
+export interface MulmoScriptData {
+  $mulmocast: { version: string; credit: string };
+  lang: SupportedLang;
+  beats: Partial<MulmoBeat>[];
+}
+
+// ============================================================================
+// Beat Generation
+// ============================================================================
+
+export function slideToBeat(
+  markdown: string,
+  note: string,
+  beat: Partial<MulmoBeat> | null,
+  style?: string
+): Partial<MulmoBeat> {
+  if (beat?.image) {
+    return { text: ("text" in beat ? beat.text : undefined) || note, image: beat.image };
+  }
+
+  const markdownLines = extractMarkdownFromSlide(markdown);
+  return {
+    text: note,
+    image: style
+      ? { type: "markdown" as const, markdown: markdownLines, style }
+      : { type: "markdown" as const, markdown: markdownLines },
+  };
+}
+
+export function slidesToMulmoScript(
+  slides: { markdown: string; note: string; beat: Partial<MulmoBeat> | null }[],
+  lang: SupportedLang,
+  style?: string
+): MulmoScriptData {
+  return {
+    $mulmocast: { version: "1.1", credit: "closing" },
+    lang,
+    beats: slides.map((slide) => slideToBeat(slide.markdown, slide.note, slide.beat, style)),
+  };
+}
+
+// ============================================================================
+// Main Pure Transform
+// ============================================================================
+
+/**
+ * Convert markdown string to MulmoScript JSON (pure function, browser-safe).
+ *
+ * Unlike `convertMarkdown()`, this function:
+ * - Takes a markdown string (not a file path)
+ * - Does not perform file I/O
+ * - Does not call LLM for narration generation
+ * - Does not auto-detect language (requires explicit `lang` option, defaults to "en")
+ */
+export function markdownToMulmoScript(
+  content: string,
+  options?: MarkdownToMulmoScriptOptions
+): MulmoScriptData {
+  const separator = options?.separator ?? "horizontal-rule";
+  const lang: SupportedLang = options?.lang ?? "en";
+
+  const rawSlides = splitIntoSlides(content, separator);
+
+  const slides = processMarkdown(rawSlides, {
+    mermaid: options?.mermaid,
+    directive: options?.directive,
+    layout: options?.layout,
+  }).map(({ markdown, beat }) => ({
+    markdown,
+    beat,
+    note: extractNotesFromSlide(markdown),
+  }));
+
+  return slidesToMulmoScript(slides, lang, options?.style);
+}

--- a/src/convert/markdown-utils-common.ts
+++ b/src/convert/markdown-utils-common.ts
@@ -1,0 +1,57 @@
+/**
+ * Markdown Converter Utilities (browser-safe)
+ *
+ * Pure functions for markdown processing with no Node.js dependencies.
+ */
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Patterns to exclude from speaker notes
+ * Common code comments that should not be treated as narration
+ * Requires colon after keyword to avoid false positives (e.g., "Note 1" is OK)
+ */
+export const EXCLUDED_NOTE_PATTERNS = [
+  /^TODO:/i,
+  /^FIXME:/i,
+  /^HACK:/i,
+  /^XXX:/i,
+  /^NOTE:/i,
+  /^BUG:/i,
+  /^WARN(ING)?:/i,
+  /^DEPRECATED:/i,
+  /^REVIEW:/i,
+];
+
+// ============================================================================
+// Speaker Notes Extraction
+// ============================================================================
+
+const isExcludedComment = (comment: string): boolean =>
+  EXCLUDED_NOTE_PATTERNS.some((pattern) => pattern.test(comment));
+
+/**
+ * Extract speaker notes from HTML comments in a slide
+ * Excludes directive-like comments and common code comments (TODO, FIXME, etc.)
+ */
+export function extractNotesFromSlide(slideContent: string): string {
+  const commentRegex = /<!--\s*([\s\S]*?)\s*-->/g;
+  return [...slideContent.matchAll(commentRegex)]
+    .map((m) => m[1].trim())
+    .filter((comment) => comment.length > 0)
+    .filter((comment) => !isExcludedComment(comment))
+    .join("\n");
+}
+
+/**
+ * Extract markdown content from a slide (removes HTML comments)
+ */
+export function extractMarkdownFromSlide(slideContent: string): string[] {
+  const slideWithoutNotes = slideContent.replace(/<!--\s*[\s\S]*?\s*-->/g, "");
+  return slideWithoutNotes
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/src/convert/markdown-utils.ts
+++ b/src/convert/markdown-utils.ts
@@ -10,6 +10,13 @@ import { mulmoScriptSchema, type MulmoBeat } from "mulmocast";
 import type { SupportedLang } from "../utils/lang";
 import type { SeparatorMode } from "./markdown-plugins";
 
+// Re-export browser-safe utilities
+export {
+  EXCLUDED_NOTE_PATTERNS,
+  extractNotesFromSlide,
+  extractMarkdownFromSlide,
+} from "./markdown-utils-common";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -41,23 +48,6 @@ export interface ConvertMarkdownResult {
 // Constants
 // ============================================================================
 
-/**
- * Patterns to exclude from speaker notes
- * Common code comments that should not be treated as narration
- * Requires colon after keyword to avoid false positives (e.g., "Note 1" is OK)
- */
-export const EXCLUDED_NOTE_PATTERNS = [
-  /^TODO:/i,
-  /^FIXME:/i,
-  /^HACK:/i,
-  /^XXX:/i,
-  /^NOTE:/i,
-  /^BUG:/i,
-  /^WARN(ING)?:/i,
-  /^DEPRECATED:/i,
-  /^REVIEW:/i,
-];
-
 export const SEPARATOR_CHOICES = [
   "horizontal-rule",
   "heading",
@@ -68,37 +58,6 @@ export const SEPARATOR_CHOICES = [
   "comment",
   "page-break",
 ] as const;
-
-// ============================================================================
-// Speaker Notes Extraction
-// ============================================================================
-
-const isExcludedComment = (comment: string): boolean =>
-  EXCLUDED_NOTE_PATTERNS.some((pattern) => pattern.test(comment));
-
-/**
- * Extract speaker notes from HTML comments in a slide
- * Excludes directive-like comments and common code comments (TODO, FIXME, etc.)
- */
-export function extractNotesFromSlide(slideContent: string): string {
-  const commentRegex = /<!--\s*([\s\S]*?)\s*-->/g;
-  return [...slideContent.matchAll(commentRegex)]
-    .map((m) => m[1].trim())
-    .filter((comment) => comment.length > 0)
-    .filter((comment) => !isExcludedComment(comment))
-    .join("\n");
-}
-
-/**
- * Extract markdown content from a slide (removes HTML comments)
- */
-export function extractMarkdownFromSlide(slideContent: string): string[] {
-  const slideWithoutNotes = slideContent.replace(/<!--\s*[\s\S]*?\s*-->/g, "");
-  return slideWithoutNotes
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
 
 // ============================================================================
 // File I/O

--- a/src/convert/markdown.ts
+++ b/src/convert/markdown.ts
@@ -24,38 +24,11 @@ import {
   setupOutputDirectory,
   writeMulmoScript,
 } from "./markdown-utils";
+import { slidesToMulmoScript } from "./markdown-transform";
 
 // Re-export types for external use
 export type { ConvertMarkdownOptions, ConvertMarkdownResult };
 export { extractNotesFromSlide, extractMarkdownFromSlide };
-
-// ============================================================================
-// Beat Generation
-// ============================================================================
-
-function slideToBeat(slide: Slide, style?: string) {
-  // Use plugin-generated beat if available (e.g., mermaid with row-2 layout)
-  if (slide.beat?.image) {
-    return { text: slide.beat.text || slide.note, image: slide.beat.image };
-  }
-
-  // Default: markdown beat
-  const markdown = extractMarkdownFromSlide(slide.markdown);
-  return {
-    text: slide.note,
-    image: style
-      ? { type: "markdown" as const, markdown, style }
-      : { type: "markdown" as const, markdown },
-  };
-}
-
-function slidesToMulmoScript(slides: Slide[], lang: SupportedLang, style?: string) {
-  return {
-    $mulmocast: { version: "1.1", credit: "closing" },
-    lang,
-    beats: slides.map((slide) => slideToBeat(slide, style)),
-  };
-}
 
 /**
  * Convert markdown file to MulmoScript

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,0 +1,13 @@
+/**
+ * Browser entry point
+ *
+ * Only exports browser-safe functions with no Node.js dependencies.
+ * Use this entry point for browser environments (Vue, React, Vite, etc.).
+ *
+ * @example
+ * import { markdownToMulmoScript } from "@mulmocast/slide/browser";
+ *
+ * const result = markdownToMulmoScript(markdownContent, { lang: "ja" });
+ */
+
+export * from "./index.common";

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -1,0 +1,30 @@
+/**
+ * Common exports (browser-safe)
+ *
+ * This module contains only pure functions with no Node.js dependencies.
+ * Safe to use in browser environments (Vue, React, Vite, etc.).
+ */
+
+// Main transform function
+export {
+  markdownToMulmoScript,
+  slideToBeat,
+  slidesToMulmoScript,
+} from "./convert/markdown-transform";
+export type { MarkdownToMulmoScriptOptions, MulmoScriptData } from "./convert/markdown-transform";
+
+// Plugin system
+export { splitIntoSlides, processMarkdown } from "./convert/markdown-plugins/index";
+export type { SeparatorMode, MarkdownConvertOptions } from "./convert/markdown-plugins/types";
+
+// Plugins
+export { directivePlugin } from "./convert/markdown-plugins/directive";
+export { mermaidPlugin } from "./convert/markdown-plugins/mermaid";
+export { layoutPlugin } from "./convert/markdown-plugins/layout";
+
+// Utilities (browser-safe subset)
+export { extractNotesFromSlide, extractMarkdownFromSlide } from "./convert/markdown-utils-common";
+
+// Language types and validation (browser-safe)
+export type { SupportedLang } from "./utils/lang-common";
+export { SUPPORTED_LANGS, DEFAULT_LANG, isValidLang } from "./utils/lang-common";

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,0 +1,16 @@
+/**
+ * Node.js entry point
+ *
+ * Re-exports all browser-safe utilities plus Node-specific functions
+ * that depend on file I/O, process.env, franc, LLM, etc.
+ */
+
+// Browser-safe exports
+export * from "./index.common";
+
+// Node-specific: file-based markdown converter
+export { convertMarkdown } from "./convert/markdown";
+export type { ConvertMarkdownOptions, ConvertMarkdownResult } from "./convert/markdown-utils";
+
+// Node-specific: language detection (franc, process.env)
+export { resolveLang, detectLang, getLangFromEnv, langOption } from "./utils/lang";

--- a/src/utils/lang-common.ts
+++ b/src/utils/lang-common.ts
@@ -1,0 +1,14 @@
+/**
+ * Language utilities (browser-safe)
+ *
+ * No Node.js dependencies (no franc, no process.env).
+ */
+
+export const SUPPORTED_LANGS = ["en", "ja", "fr", "de"] as const;
+export type SupportedLang = (typeof SUPPORTED_LANGS)[number];
+
+export const DEFAULT_LANG: SupportedLang = "en";
+
+export function isValidLang(lang: string): lang is SupportedLang {
+  return SUPPORTED_LANGS.includes(lang as SupportedLang);
+}

--- a/src/utils/lang.ts
+++ b/src/utils/lang.ts
@@ -1,10 +1,10 @@
 import { franc } from "franc";
+import { isValidLang, DEFAULT_LANG } from "./lang-common";
+import type { SupportedLang } from "./lang-common";
 
-// Supported languages
-export const SUPPORTED_LANGS = ["en", "ja", "fr", "de"] as const;
-export type SupportedLang = (typeof SUPPORTED_LANGS)[number];
-
-export const DEFAULT_LANG: SupportedLang = "en";
+// Re-export browser-safe utilities
+export { SUPPORTED_LANGS, DEFAULT_LANG, isValidLang } from "./lang-common";
+export type { SupportedLang } from "./lang-common";
 
 // Map franc's ISO 639-3 codes to our supported 2-letter codes
 const FRANC_TO_LANG: Record<string, SupportedLang> = {
@@ -13,10 +13,6 @@ const FRANC_TO_LANG: Record<string, SupportedLang> = {
   fra: "fr",
   deu: "de",
 };
-
-export function isValidLang(lang: string): lang is SupportedLang {
-  return SUPPORTED_LANGS.includes(lang as SupportedLang);
-}
 
 export function getLangFromEnv(): SupportedLang | undefined {
   const envLang = process.env.MULMO_LANG;
@@ -50,7 +46,7 @@ export const langOption = {
   l: {
     alias: "lang",
     type: "string" as const,
-    choices: SUPPORTED_LANGS as unknown as string[],
+    choices: ["en", "ja", "fr", "de"] as unknown as string[],
     description: "Language for the MulmoScript",
     default: undefined,
   },

--- a/tests/test_markdown_transform.ts
+++ b/tests/test_markdown_transform.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for markdownToMulmoScript pure transform
+ *
+ * Tests the browser-safe markdown → MulmoScript conversion.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { markdownToMulmoScript, slideToBeat, slidesToMulmoScript } from "../src/convert/markdown-transform";
+
+describe("markdownToMulmoScript", () => {
+  it("converts simple markdown with horizontal-rule separator", () => {
+    const content = `# Slide 1
+Content 1
+<!-- Speaker note 1 -->
+
+---
+
+# Slide 2
+Content 2
+<!-- Speaker note 2 -->`;
+
+    const result = markdownToMulmoScript(content);
+
+    assert.strictEqual(result.lang, "en");
+    assert.strictEqual(result.beats.length, 2);
+    assert.strictEqual(result.$mulmocast.version, "1.1");
+    assert.strictEqual(result.beats[0].text, "Speaker note 1");
+    assert.strictEqual(result.beats[1].text, "Speaker note 2");
+  });
+
+  it("defaults to English when lang is not specified", () => {
+    const result = markdownToMulmoScript("# Hello");
+    assert.strictEqual(result.lang, "en");
+  });
+
+  it("respects lang option", () => {
+    const result = markdownToMulmoScript("# Hello", { lang: "ja" });
+    assert.strictEqual(result.lang, "ja");
+  });
+
+  it("respects separator option", () => {
+    const content = `# Slide 1
+Content 1
+
+# Slide 2
+Content 2`;
+
+    const result = markdownToMulmoScript(content, { separator: "heading" });
+    assert.strictEqual(result.beats.length, 2);
+  });
+
+  it("applies mermaid plugin when enabled", () => {
+    const content = `# Title
+<!-- Explanation -->
+
+\`\`\`mermaid
+graph TD
+  A --> B
+\`\`\`
+
+Some explanatory text that is long enough to trigger row-2 layout.`;
+
+    const result = markdownToMulmoScript(content, { mermaid: true });
+    assert.strictEqual(result.beats.length, 1);
+
+    const image = result.beats[0].image as Record<string, unknown>;
+    assert.strictEqual(image.type, "markdown");
+  });
+
+  it("applies directive plugin when enabled", () => {
+    const content = `<!-- _class: lead -->
+# Title Slide
+<!-- This is a speaker note -->`;
+
+    const result = markdownToMulmoScript(content, { directive: true });
+    assert.strictEqual(result.beats.length, 1);
+    assert.strictEqual(result.beats[0].text, "This is a speaker note");
+  });
+
+  it("applies style option to beats", () => {
+    const content = "# Hello World";
+    const result = markdownToMulmoScript(content, { style: "corporate-blue" });
+
+    const image = result.beats[0].image as Record<string, unknown>;
+    assert.strictEqual(image.style, "corporate-blue");
+  });
+
+  it("handles empty slides (filters them out)", () => {
+    const content = `# Slide 1
+
+---
+
+
+
+---
+
+# Slide 2`;
+
+    const result = markdownToMulmoScript(content);
+    assert.strictEqual(result.beats.length, 2);
+  });
+
+  it("extracts notes and excludes TODO/FIXME comments", () => {
+    const content = `# Slide
+<!-- TODO: fix this later -->
+<!-- Actual speaker note -->`;
+
+    const result = markdownToMulmoScript(content);
+    assert.strictEqual(result.beats[0].text, "Actual speaker note");
+  });
+});
+
+describe("slideToBeat", () => {
+  it("creates markdown beat from slide content", () => {
+    const result = slideToBeat("# Hello\nWorld", "speaker note", null);
+    assert.strictEqual(result.text, "speaker note");
+
+    const image = result.image as Record<string, unknown>;
+    assert.strictEqual(image.type, "markdown");
+  });
+
+  it("uses plugin-generated beat when available", () => {
+    const pluginBeat = {
+      text: "plugin text",
+      image: { type: "markdown" as const, markdown: ["test"] },
+    };
+    const result = slideToBeat("# Hello", "fallback note", pluginBeat);
+
+    assert.strictEqual(result.text, "plugin text");
+    assert.deepStrictEqual(result.image, pluginBeat.image);
+  });
+
+  it("falls back to note text when plugin beat has no text", () => {
+    const pluginBeat = {
+      image: { type: "markdown" as const, markdown: ["test"] },
+    };
+    const result = slideToBeat("# Hello", "fallback note", pluginBeat);
+
+    assert.strictEqual(result.text, "fallback note");
+  });
+
+  it("applies style to markdown beat", () => {
+    const result = slideToBeat("# Hello", "note", null, "corporate-blue");
+
+    const image = result.image as Record<string, unknown>;
+    assert.strictEqual(image.style, "corporate-blue");
+  });
+});
+
+describe("slidesToMulmoScript", () => {
+  it("creates MulmoScript structure", () => {
+    const slides = [
+      { markdown: "# Slide 1", note: "Note 1", beat: null },
+      { markdown: "# Slide 2", note: "Note 2", beat: null },
+    ];
+
+    const result = slidesToMulmoScript(slides, "ja");
+
+    assert.strictEqual(result.$mulmocast.version, "1.1");
+    assert.strictEqual(result.$mulmocast.credit, "closing");
+    assert.strictEqual(result.lang, "ja");
+    assert.strictEqual(result.beats.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract pure `markdownToMulmoScript()` function from Node-dependent `convertMarkdown()` into `src/convert/markdown-transform.ts` — no fs/path/franc/LLM dependencies
- Split browser-safe parts of `lang.ts` and `markdown-utils.ts` into `*-common.ts` modules
- Add conditional package exports: `@mulmocast/slide` (Node) and `@mulmocast/slide/browser`

## Usage

```typescript
// Browser (Vue/React/Vite)
import { markdownToMulmoScript } from "@mulmocast/slide/browser";
const result = markdownToMulmoScript(content, { lang: "ja", mermaid: true });

// Vue reactive
const result = computed(() => markdownToMulmoScript(content.value, options.value));

// Node.js (full API including file I/O and LLM)
import { convertMarkdown, markdownToMulmoScript } from "@mulmocast/slide";
```

## New Files

| File | Purpose |
|------|---------|
| `src/convert/markdown-transform.ts` | Pure `markdownToMulmoScript()`, `slideToBeat()`, `slidesToMulmoScript()` |
| `src/convert/markdown-utils-common.ts` | Browser-safe `extractNotesFromSlide()`, `extractMarkdownFromSlide()` |
| `src/utils/lang-common.ts` | Browser-safe `isValidLang()`, `SupportedLang`, `SUPPORTED_LANGS` |
| `src/index.common.ts` | Shared browser-safe exports |
| `src/index.node.ts` | Node entry point (common + Node-specific) |
| `src/index.browser.ts` | Browser entry point (common only) |
| `tests/test_markdown_transform.ts` | 14 unit tests for the pure transform |

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn lint` passes
- [x] `yarn test` — all 163 tests pass (including 14 new ones)
- [ ] Verify browser import works in a Vite project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser compatibility with dedicated entry point
  * Introduced markdown-to-MulmoScript conversion with extensible plugin system (mermaid, directive, layout support)
  * Added multi-language support (English, Japanese, French, German)

* **Chores**
  * Reorganized package entry points and exports for improved browser and Node.js environment support
  * Refactored markdown utilities into modular, browser-safe components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->