### PR TITLE
refactor: migrate from CommonJS to TypeScript ESM (NodeNext)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "author": "receptron",
-  "type": "commonjs",
+  "type": "module",
   "main": "lib/index.node.js",
   "types": "lib/index.node.d.ts",
   "exports": {

--- a/src/actions/bundle.ts
+++ b/src/actions/bundle.ts
@@ -3,7 +3,7 @@
 import { audio, images, translate, mulmoViewerBundle, bundleTargetLang } from "mulmocast";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { initializeContext, runAction } from "./common";
+import { initializeContext, runAction } from "./common.js";
 
 export async function runMulmoBundle(mulmoScriptPath: string, outputDir: string): Promise<void> {
   console.log(`\nGenerating bundle with mulmo...`);

--- a/src/actions/common.ts
+++ b/src/actions/common.ts
@@ -1,13 +1,17 @@
 import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "child_process";
-import { convertPptx } from "../convert/pptx";
-import { convertMarp } from "../convert/marp";
-import { convertPdf } from "../convert/pdf";
-import { convertMovie } from "../convert/movie";
+import { fileURLToPath } from "node:url";
+import { convertPptx } from "../convert/pptx.js";
+import { convertMarp } from "../convert/marp.js";
+import { convertPdf } from "../convert/pdf.js";
+import { convertMovie } from "../convert/movie.js";
 import { getFileObject, initializeContextFromFiles } from "mulmocast";
 import type { MulmoStudioContext } from "mulmocast";
-import type { SupportedLang } from "../utils/lang";
+import type { SupportedLang } from "../utils/lang.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Get package root directory (works for both development and npm installed)
 export function getPackageRoot(): string {

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -3,7 +3,7 @@
 import { audio, images, movie, translate, captions, MulmoStudioContextMethods } from "mulmocast";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { initializeContext, runAction } from "./common";
+import { initializeContext, runAction } from "./common.js";
 
 export interface MovieOptions {
   targetLang?: string;

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -3,15 +3,19 @@
 import * as http from "http";
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 import {
   saveBeatText,
   transcribeAudio,
   parseRequestBody,
   type SaveBeatTextRequest,
   type TranscribeRequest,
-} from "../utils/audio-save";
-import { findBundles, getMimeType, isValidFile, createFileStream } from "../utils/bundle-server";
+} from "../utils/audio-save.js";
+import { findBundles, getMimeType, isValidFile, createFileStream } from "../utils/bundle-server.js";
 
 // Load .env file
 dotenv.config();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,25 +2,25 @@
 
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { convertMarp } from "./convert/marp";
-import { convertMarkdown } from "./convert/markdown";
-import { convertPptx } from "./convert/pptx";
-import { convertPdf } from "./convert/pdf";
-import { convertMovie } from "./convert/movie";
+import { convertMarp } from "./convert/marp.js";
+import { convertMarkdown } from "./convert/markdown.js";
+import { convertPptx } from "./convert/pptx.js";
+import { convertPdf } from "./convert/pdf.js";
+import { convertMovie } from "./convert/movie.js";
 import { execSync } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
-import { langOption, type SupportedLang } from "./utils/lang";
+import { langOption, type SupportedLang } from "./utils/lang.js";
 import {
   detectFileType,
   getBasename,
   convertToMulmoScript,
   getMulmoScriptPath,
   getKeynoteScriptPath,
-} from "./actions/common";
-import { runMulmoMovie } from "./actions/movie";
-import { runMulmoBundle } from "./actions/bundle";
-import { startPreviewServer } from "./actions/preview";
+} from "./actions/common.js";
+import { runMulmoMovie } from "./actions/movie.js";
+import { runMulmoBundle } from "./actions/bundle.js";
+import { startPreviewServer } from "./actions/preview.js";
 
 // Common options for conversion commands
 const convertOptions = {
@@ -173,7 +173,7 @@ async function runConvert(
         inputPath,
         lang: options.lang,
         generateText: options.generateText,
-        separator: options.separator as import("./convert/markdown-plugins").SeparatorMode,
+        separator: options.separator as import("./convert/markdown-plugins/index.js").SeparatorMode,
         mermaid: options.mermaid,
         directive: options.directive,
         layout: options.layout,
@@ -300,7 +300,7 @@ async function runUpload(basename: string) {
   const bundleDir = path.join(outputDir, bundleEntry.name);
 
   // Dynamic import to avoid loading upload code unnecessarily
-  const { uploadBundleDir } = await import("./actions/upload");
+  const { uploadBundleDir } = await import("./actions/upload.js");
   const result = await uploadBundleDir(bundleDir, apiKey);
 
   console.log(`\n✓ Upload complete!`);

--- a/src/convert/markdown-plugins/directive.ts
+++ b/src/convert/markdown-plugins/directive.ts
@@ -12,7 +12,7 @@
  * - <!-- _paginate: ... -->
  */
 
-import type { MarkdownPlugin } from "./types";
+import type { MarkdownPlugin } from "./types.js";
 
 // Directive pattern: <!-- _key: value -->
 const DIRECTIVE_REGEX = /<!--\s*_(\w+):\s*(.+?)\s*-->/g;

--- a/src/convert/markdown-plugins/index.ts
+++ b/src/convert/markdown-plugins/index.ts
@@ -6,10 +6,15 @@
  */
 
 import type { MulmoBeat } from "mulmocast";
-import type { MarkdownPlugin, PluginContext, SeparatorMode, MarkdownConvertOptions } from "./types";
+import type {
+  MarkdownPlugin,
+  PluginContext,
+  SeparatorMode,
+  MarkdownConvertOptions,
+} from "./types.js";
 
 // Re-export types
-export type { SeparatorMode, MarkdownConvertOptions } from "./types";
+export type { SeparatorMode, MarkdownConvertOptions } from "./types.js";
 
 /** Result of processing a single slide */
 export type ProcessedSlide = {
@@ -18,9 +23,9 @@ export type ProcessedSlide = {
 };
 
 // Built-in plugins
-import { mermaidPlugin } from "./mermaid";
-import { directivePlugin } from "./directive";
-import { layoutPlugin } from "./layout";
+import { mermaidPlugin } from "./mermaid.js";
+import { directivePlugin } from "./directive.js";
+import { layoutPlugin } from "./layout.js";
 
 /**
  * Get separator regex pattern

--- a/src/convert/markdown-plugins/layout.ts
+++ b/src/convert/markdown-plugins/layout.ts
@@ -62,7 +62,7 @@
  * - Mermaid plugin takes precedence for ```mermaid blocks
  */
 
-import type { MarkdownPlugin } from "./types";
+import type { MarkdownPlugin } from "./types.js";
 import type { MulmoBeat } from "mulmocast";
 
 // ============================================================================

--- a/src/convert/markdown-plugins/mermaid.ts
+++ b/src/convert/markdown-plugins/mermaid.ts
@@ -5,7 +5,7 @@
  * This allows mermaid diagrams to be displayed alongside explanatory text.
  */
 
-import type { MarkdownPlugin } from "./types";
+import type { MarkdownPlugin } from "./types.js";
 import type { MulmoBeat } from "mulmocast";
 
 const MERMAID_REGEX = /```mermaid\n([\s\S]*?)```/g;

--- a/src/convert/markdown-transform.ts
+++ b/src/convert/markdown-transform.ts
@@ -6,10 +6,10 @@
  */
 
 import type { MulmoBeat } from "mulmocast";
-import type { SupportedLang } from "../utils/lang-common";
-import type { SeparatorMode } from "./markdown-plugins/types";
-import { splitIntoSlides, processMarkdown } from "./markdown-plugins/index";
-import { extractNotesFromSlide, extractMarkdownFromSlide } from "./markdown-utils-common";
+import type { SupportedLang } from "../utils/lang-common.js";
+import type { SeparatorMode } from "./markdown-plugins/types.js";
+import { splitIntoSlides, processMarkdown } from "./markdown-plugins/index.js";
+import { extractNotesFromSlide, extractMarkdownFromSlide } from "./markdown-utils-common.js";
 
 export interface MarkdownToMulmoScriptOptions {
   lang?: SupportedLang;

--- a/src/convert/markdown-utils.ts
+++ b/src/convert/markdown-utils.ts
@@ -7,15 +7,15 @@
 import * as fs from "fs";
 import * as path from "path";
 import { mulmoScriptSchema, type MulmoBeat } from "mulmocast";
-import type { SupportedLang } from "../utils/lang";
-import type { SeparatorMode } from "./markdown-plugins";
+import type { SupportedLang } from "../utils/lang.js";
+import type { SeparatorMode } from "./markdown-plugins/index.js";
 
 // Re-export browser-safe utilities
 export {
   EXCLUDED_NOTE_PATTERNS,
   extractNotesFromSlide,
   extractMarkdownFromSlide,
-} from "./markdown-utils-common";
+} from "./markdown-utils-common.js";
 
 // ============================================================================
 // Types

--- a/src/convert/markdown.ts
+++ b/src/convert/markdown.ts
@@ -10,9 +10,9 @@
 import * as path from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { resolveLang, langOption, type SupportedLang } from "../utils/lang";
-import { generateTextFromMarkdown } from "../utils/llm";
-import { splitIntoSlides, processMarkdown, type SeparatorMode } from "./markdown-plugins";
+import { resolveLang, langOption, type SupportedLang } from "../utils/lang.js";
+import { generateTextFromMarkdown } from "../utils/llm.js";
+import { splitIntoSlides, processMarkdown, type SeparatorMode } from "./markdown-plugins/index.js";
 import {
   type Slide,
   type ConvertMarkdownOptions,
@@ -23,8 +23,8 @@ import {
   readMarkdownFile,
   setupOutputDirectory,
   writeMulmoScript,
-} from "./markdown-utils";
-import { slidesToMulmoScript } from "./markdown-transform";
+} from "./markdown-utils.js";
+import { slidesToMulmoScript } from "./markdown-transform.js";
 
 // Re-export types for external use
 export type { ConvertMarkdownOptions, ConvertMarkdownResult };
@@ -176,7 +176,9 @@ async function main() {
   });
 }
 
-if (require.main === module) {
+const isDirectRun =
+  process.argv[1]?.endsWith("markdown.ts") || process.argv[1]?.endsWith("markdown.js");
+if (isDirectRun) {
   main().catch((error) => {
     console.error("\n✗ Error:", error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/src/convert/marp.ts
+++ b/src/convert/marp.ts
@@ -9,9 +9,9 @@ import type { z } from "zod";
 type MulmoScriptInput = z.input<typeof mulmoScriptSchema>;
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { resolveLang, langOption, type SupportedLang } from "../utils/lang";
-import { generateTextFromMarkdown } from "../utils/llm";
-import { extractNotesFromSlide, extractMarkdownFromSlide } from "./markdown-utils-common";
+import { resolveLang, langOption, type SupportedLang } from "../utils/lang.js";
+import { generateTextFromMarkdown } from "../utils/llm.js";
+import { extractNotesFromSlide, extractMarkdownFromSlide } from "./markdown-utils-common.js";
 
 // Re-export for backward compatibility (used by tests and external consumers)
 export { extractNotesFromSlide, extractMarkdownFromSlide };
@@ -385,7 +385,8 @@ async function main() {
   });
 }
 
-if (require.main === module) {
+const isDirectRun = process.argv[1]?.endsWith("marp.ts") || process.argv[1]?.endsWith("marp.js");
+if (isDirectRun) {
   main().catch((error) => {
     console.error("\n✗ Error:", error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/src/convert/movie.ts
+++ b/src/convert/movie.ts
@@ -3,12 +3,12 @@ import * as path from "path";
 import { execSync, spawn } from "child_process";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { isValidLang, langOption, type SupportedLang } from "../utils/lang";
-import { checkDependencies } from "../utils/dependencies";
+import { isValidLang, langOption, type SupportedLang } from "../utils/lang.js";
+import { checkDependencies } from "../utils/dependencies.js";
 import OpenAI from "openai";
 import { mulmoScriptSchema, type MulmoBeat } from "mulmocast";
 import type { z } from "zod";
-import { generateMovieBundle } from "./movie_bundle";
+import { generateMovieBundle } from "./movie_bundle.js";
 
 type MulmoScriptInput = z.input<typeof mulmoScriptSchema>;
 
@@ -483,7 +483,8 @@ async function main() {
   });
 }
 
-if (require.main === module) {
+const isDirectRun = process.argv[1]?.endsWith("movie.ts") || process.argv[1]?.endsWith("movie.js");
+if (isDirectRun) {
   main().catch((error) => {
     console.error("Error:", error.message);
     process.exit(1);

--- a/src/convert/pdf.ts
+++ b/src/convert/pdf.ts
@@ -4,14 +4,14 @@ import * as fs from "fs";
 import * as path from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { resolveLang, langOption, type SupportedLang } from "../utils/lang";
+import { resolveLang, langOption, type SupportedLang } from "../utils/lang.js";
 import {
   convertPdfToImages,
   buildMulmoScriptFromImages,
   writeMulmoScript,
   extractTextFromPdf,
-} from "../utils/pdf";
-import { checkDependencies } from "../utils/dependencies";
+} from "../utils/pdf.js";
+import { checkDependencies } from "../utils/dependencies.js";
 
 export interface ConvertPdfOptions {
   inputPath: string;
@@ -117,7 +117,8 @@ async function main() {
   });
 }
 
-if (require.main === module) {
+const isDirectRun = process.argv[1]?.endsWith("pdf.ts") || process.argv[1]?.endsWith("pdf.js");
+if (isDirectRun) {
   main().catch((error) => {
     console.error("Error:", error.message);
     process.exit(1);

--- a/src/convert/pptx.ts
+++ b/src/convert/pptx.ts
@@ -1,13 +1,14 @@
 import type { Buffer } from "buffer";
 import Converter from "ppt-png";
-import PptxParser from "node-pptx-parser";
+import PptxParserModule from "node-pptx-parser";
+const PptxParser = PptxParserModule as unknown as typeof PptxParserModule.default;
 import * as fs from "fs";
 import * as path from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { resolveLang, langOption, type SupportedLang } from "../utils/lang";
-import { convertPdfToImages, buildMulmoScriptFromImages, writeMulmoScript } from "../utils/pdf";
-import { checkDependencies } from "../utils/dependencies";
+import { resolveLang, langOption, type SupportedLang } from "../utils/lang.js";
+import { convertPdfToImages, buildMulmoScriptFromImages, writeMulmoScript } from "../utils/pdf.js";
+import { checkDependencies } from "../utils/dependencies.js";
 import unzipper from "unzipper";
 import { parseString } from "xml2js";
 
@@ -421,7 +422,8 @@ async function main() {
   });
 }
 
-if (require.main === module) {
+const isDirectRun = process.argv[1]?.endsWith("pptx.ts") || process.argv[1]?.endsWith("pptx.js");
+if (isDirectRun) {
   main().catch((error) => {
     console.error("Error:", error.message);
     process.exit(1);

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -10,4 +10,4 @@
  * const result = markdownToMulmoScript(markdownContent, { lang: "ja" });
  */
 
-export * from "./index.common";
+export * from "./index.common.js";

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -10,21 +10,27 @@ export {
   markdownToMulmoScript,
   slideToBeat,
   slidesToMulmoScript,
-} from "./convert/markdown-transform";
-export type { MarkdownToMulmoScriptOptions, MulmoScriptData } from "./convert/markdown-transform";
+} from "./convert/markdown-transform.js";
+export type {
+  MarkdownToMulmoScriptOptions,
+  MulmoScriptData,
+} from "./convert/markdown-transform.js";
 
 // Plugin system
-export { splitIntoSlides, processMarkdown } from "./convert/markdown-plugins/index";
-export type { SeparatorMode, MarkdownConvertOptions } from "./convert/markdown-plugins/types";
+export { splitIntoSlides, processMarkdown } from "./convert/markdown-plugins/index.js";
+export type { SeparatorMode, MarkdownConvertOptions } from "./convert/markdown-plugins/types.js";
 
 // Plugins
-export { directivePlugin } from "./convert/markdown-plugins/directive";
-export { mermaidPlugin } from "./convert/markdown-plugins/mermaid";
-export { layoutPlugin } from "./convert/markdown-plugins/layout";
+export { directivePlugin } from "./convert/markdown-plugins/directive.js";
+export { mermaidPlugin } from "./convert/markdown-plugins/mermaid.js";
+export { layoutPlugin } from "./convert/markdown-plugins/layout.js";
 
 // Utilities (browser-safe subset)
-export { extractNotesFromSlide, extractMarkdownFromSlide } from "./convert/markdown-utils-common";
+export {
+  extractNotesFromSlide,
+  extractMarkdownFromSlide,
+} from "./convert/markdown-utils-common.js";
 
 // Language types and validation (browser-safe)
-export type { SupportedLang } from "./utils/lang-common";
-export { SUPPORTED_LANGS, DEFAULT_LANG, isValidLang } from "./utils/lang-common";
+export type { SupportedLang } from "./utils/lang-common.js";
+export { SUPPORTED_LANGS, DEFAULT_LANG, isValidLang } from "./utils/lang-common.js";

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -6,11 +6,11 @@
  */
 
 // Browser-safe exports
-export * from "./index.common";
+export * from "./index.common.js";
 
 // Node-specific: file-based markdown converter
-export { convertMarkdown } from "./convert/markdown";
-export type { ConvertMarkdownOptions, ConvertMarkdownResult } from "./convert/markdown-utils";
+export { convertMarkdown } from "./convert/markdown.js";
+export type { ConvertMarkdownOptions, ConvertMarkdownResult } from "./convert/markdown-utils.js";
 
 // Node-specific: language detection (franc, process.env)
-export { resolveLang, detectLang, getLangFromEnv, langOption } from "./utils/lang";
+export { resolveLang, detectLang, getLangFromEnv, langOption } from "./utils/lang.js";

--- a/src/utils/lang.ts
+++ b/src/utils/lang.ts
@@ -1,10 +1,10 @@
 import { franc } from "franc";
-import { isValidLang, DEFAULT_LANG } from "./lang-common";
-import type { SupportedLang } from "./lang-common";
+import { isValidLang, DEFAULT_LANG } from "./lang-common.js";
+import type { SupportedLang } from "./lang-common.js";
 
 // Re-export browser-safe utilities
-export { SUPPORTED_LANGS, DEFAULT_LANG, isValidLang } from "./lang-common";
-export type { SupportedLang } from "./lang-common";
+export { SUPPORTED_LANGS, DEFAULT_LANG, isValidLang } from "./lang-common.js";
+export type { SupportedLang } from "./lang-common.js";
 
 // Map franc's ISO 639-3 codes to our supported 2-letter codes
 const FRANC_TO_LANG: Record<string, SupportedLang> = {

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
 import * as fs from "fs";
 import * as path from "path";
-import type { SupportedLang } from "./lang";
+import type { SupportedLang } from "./lang.js";
 
 let openaiClient: OpenAI | null = null;
 

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -3,8 +3,8 @@ import * as path from "path";
 import { execSync } from "child_process";
 import { mulmoScriptSchema, type MulmoBeat } from "mulmocast";
 import type { z } from "zod";
-import type { SupportedLang } from "./lang";
-import { generateTextFromImages } from "./llm";
+import type { SupportedLang } from "./lang.js";
+import { generateTextFromImages } from "./llm.js";
 
 type MulmoScriptInput = z.input<typeof mulmoScriptSchema>;
 type MulmoScriptOutput = z.output<typeof mulmoScriptSchema>;

--- a/tests/test_common.ts
+++ b/tests/test_common.ts
@@ -7,7 +7,7 @@ import {
   getMulmoScriptPath,
   getPackageRoot,
   getKeynoteScriptPath,
-} from "../src/actions/common";
+} from "../src/actions/common.js";
 
 // detectFileType tests
 test("detectFileType: should detect PPTX files", () => {

--- a/tests/test_dependencies.ts
+++ b/tests/test_dependencies.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { CONVERTER_DEPENDENCIES } from "../src/utils/dependencies";
+import { CONVERTER_DEPENDENCIES } from "../src/utils/dependencies.js";
 
 // CONVERTER_DEPENDENCIES tests
 test("CONVERTER_DEPENDENCIES: pptx requires libreoffice, imagemagick, ghostscript", () => {

--- a/tests/test_lang.ts
+++ b/tests/test_lang.ts
@@ -6,7 +6,7 @@ import {
   detectLang,
   SUPPORTED_LANGS,
   DEFAULT_LANG,
-} from "../src/utils/lang";
+} from "../src/utils/lang.js";
 
 // isValidLang tests
 test("isValidLang: should return true for supported languages", () => {

--- a/tests/test_layout_plugin.ts
+++ b/tests/test_layout_plugin.ts
@@ -15,7 +15,7 @@ import {
   tryH3GridLayout,
   tryH2FourPlusLayout,
   tryH2TwoLayout,
-} from "../src/convert/markdown-plugins/layout";
+} from "../src/convert/markdown-plugins/layout.js";
 
 // Helper to extract layout type from result
 const getLayoutType = (

--- a/tests/test_markdown_plugins.ts
+++ b/tests/test_markdown_plugins.ts
@@ -16,7 +16,7 @@ import {
   buildPluginList,
   applyPreprocessors,
   findBeat,
-} from "../src/convert/markdown-plugins";
+} from "../src/convert/markdown-plugins/index.js";
 
 describe("Separator Modes", () => {
   describe("horizontal-rule (default)", () => {

--- a/tests/test_markdown_transform.ts
+++ b/tests/test_markdown_transform.ts
@@ -6,7 +6,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { markdownToMulmoScript, slideToBeat, slidesToMulmoScript } from "../src/convert/markdown-transform";
+import { markdownToMulmoScript, slideToBeat, slidesToMulmoScript } from "../src/convert/markdown-transform.js";
 
 describe("markdownToMulmoScript", () => {
   it("converts simple markdown with horizontal-rule separator", () => {

--- a/tests/test_marp_extract.ts
+++ b/tests/test_marp_extract.ts
@@ -6,7 +6,7 @@ import {
   extractNotesFromSlides,
   extractMarkdownFromSlide,
   extractMarkdownFromSlides,
-} from "../src/convert/marp";
+} from "../src/convert/marp.js";
 
 test("parseSlides: should split content by slide separator", () => {
   const content = `# Slide 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./lib",
     "rootDir": "./src",
@@ -13,7 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

- Migrate from CJS (`"type": "commonjs"`, `"module": "commonjs"`) to ESM (`"type": "module"`, `"module": "NodeNext"`)
- Add `.js` extensions to all relative imports/exports (82 additions across 29 files)
- Replace `__dirname` with `fileURLToPath(import.meta.url)` in 2 files
- Replace `require.main === module` with `process.argv[1]?.endsWith()` pattern in 5 files
- Fix `node-pptx-parser` default import for NodeNext type resolution

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes
- [x] `yarn test` — all 163 tests pass
- [x] `yarn cli --help` works
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module system configuration for improved compatibility across different environments
  * Enhanced module resolution behavior throughout the codebase
  * Two additional functions now available for direct import: `extractNotesFromSlide` and `extractMarkdownFromSlide`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->