### PR TITLE
feat: add extend validate command

### DIFF
--- a/.claude/skills/extend/SKILL.md
+++ b/.claude/skills/extend/SKILL.md
@@ -70,13 +70,15 @@ Based on the analysis, generate:
 4. Add `outputProfiles: {}` (empty, for user to configure later)
 5. If beats don't have `id` fields, add them (e.g., `"beat-1"`, `"beat-2"`, ...)
 
-### Step 5: Write Output
+### Step 5: Write and Validate Output
 
 1. Determine output path:
    - Same directory as input: replace `mulmo_script.json` with `extended_script.json`
    - Example: `scripts/simple_text/mulmo_script.json` -> `scripts/simple_text/extended_script.json`
 2. Write the JSON with 2-space indentation
-3. Display a summary to the user:
+3. Run `mulmo-slide extend validate <output_path>` (or `yarn cli extend validate <output_path>`) to validate against the schema
+4. If validation fails, fix the errors and re-write the file, then validate again
+5. Display a summary to the user:
    - Number of beats processed
    - Sections identified
    - Key topics/keywords

--- a/.claude/skills/extend/references/extended-script-schema.md
+++ b/.claude/skills/extend/references/extended-script-schema.md
@@ -1,7 +1,7 @@
 # ExtendedScript Schema Reference
 
 This document defines the ExtendedScript format used by `mulmocast-preprocessor`.
-Source: `mulmocast-plus/packages/mulmocast-preprocessor/src/types/index.ts`
+Canonical source: `@mulmocast/extended-types` npm package (`mulmocast-plus/packages/mulmocast-extended-types/src/index.ts`)
 
 ## Type Definitions
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Commands:
   mulmo-slide movie <file>       Generate movie from presentation
   mulmo-slide bundle <file>      Generate MulmoViewer bundle from presentation
   mulmo-slide extend init        Install /extend Claude Code skill
+  mulmo-slide extend validate    Validate ExtendedScript JSON against schema
 ```
 
 The `convert` command auto-detects file format by extension (.pptx, .md, .key, .pdf).
@@ -604,6 +605,19 @@ The skill analyzes the MulmoScript (and optionally the source file) to generate:
 - `expectedQuestions` - Anticipated audience questions
 
 **Output:** `scripts/{basename}/extended_script.json`
+
+### Validating ExtendedScript
+
+Validate an ExtendedScript JSON file against the schema:
+
+```bash
+mulmo-slide extend validate scripts/simple_text/extended_script.json
+
+# Development
+yarn cli extend validate scripts/simple_text/extended_script.json
+```
+
+Outputs beat count, scriptMeta presence, meta coverage percentage, and sections found.
 
 ### Using with mulmocast-preprocessor
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@marp-team/marp-cli": "^4.0.0",
+    "@mulmocast/extended-types": "^0.1.0",
     "dotenv": "^17.2.4",
     "franc": "^6.2.0",
     "mulmocast": "^2.1.35",

--- a/src/actions/extend-validate.ts
+++ b/src/actions/extend-validate.ts
@@ -1,0 +1,75 @@
+import * as fs from "fs";
+import * as path from "path";
+import { extendedScriptSchema } from "@mulmocast/extended-types";
+
+interface ValidationSummary {
+  beatCount: number;
+  hasScriptMeta: boolean;
+  metaCoverage: number;
+  sections: string[];
+}
+
+const summarizeScript = (data: unknown): ValidationSummary => {
+  const script = data as Record<string, unknown>;
+  const beats = script.beats as Record<string, unknown>[];
+  const beatsWithMeta = beats.filter((b) => b.meta);
+  const sections = [
+    ...new Set(
+      beats.map((b) => (b.meta as Record<string, unknown> | undefined)?.section).filter(Boolean)
+    ),
+  ] as string[];
+
+  return {
+    beatCount: beats.length,
+    hasScriptMeta: !!script.scriptMeta,
+    metaCoverage: beats.length > 0 ? Math.round((beatsWithMeta.length / beats.length) * 100) : 0,
+    sections,
+  };
+};
+
+const formatZodError = (error: {
+  issues: Array<{ path: PropertyKey[]; message: string }>;
+}): string => {
+  const lines = error.issues.map((issue) => {
+    const pathStr = issue.path.length > 0 ? issue.path.map((p) => String(p)).join(".") : "(root)";
+    return `  - ${pathStr}: ${issue.message}`;
+  });
+  return lines.join("\n");
+};
+
+export const runExtendValidate = (filePath: string): void => {
+  const resolvedPath = path.resolve(filePath);
+
+  if (!fs.existsSync(resolvedPath)) {
+    console.error(`File not found: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  let data: unknown;
+  try {
+    const content = fs.readFileSync(resolvedPath, "utf-8");
+    data = JSON.parse(content);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(`Failed to parse JSON: ${message}`);
+    process.exit(1);
+  }
+
+  const result = extendedScriptSchema.safeParse(data);
+
+  if (!result.success) {
+    console.error(`\n✗ Validation failed: ${resolvedPath}\n`);
+    console.error(formatZodError(result.error));
+    process.exit(1);
+  }
+
+  const summary = summarizeScript(data);
+
+  console.log(`\n✓ Valid ExtendedScript: ${resolvedPath}`);
+  console.log(`  Beats: ${summary.beatCount}`);
+  console.log(`  ScriptMeta: ${summary.hasScriptMeta ? "yes" : "no"}`);
+  console.log(`  Meta coverage: ${summary.metaCoverage}%`);
+  if (summary.sections.length > 0) {
+    console.log(`  Sections: ${summary.sections.join(", ")}`);
+  }
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -532,7 +532,22 @@ yargs(hideBin(process.argv))
             runExtendInit();
           }
         )
-        .demandCommand(1, "Use 'mulmo-slide extend init' to install the skill");
+        .command(
+          "validate <file>",
+          "Validate an ExtendedScript JSON file against the schema",
+          (yargs) => {
+            return yargs.positional("file", {
+              describe: "ExtendedScript JSON file to validate",
+              type: "string",
+              demandOption: true,
+            });
+          },
+          async (argv) => {
+            const { runExtendValidate } = await import("./actions/extend-validate.js");
+            runExtendValidate(argv.file);
+          }
+        )
+        .demandCommand(1, "Use 'mulmo-slide extend init' or 'mulmo-slide extend validate <file>'");
     },
     () => {}
   )

--- a/tests/test_extend_validate.ts
+++ b/tests/test_extend_validate.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+
+const CLI = "npx tsx src/cli.ts";
+
+const createTempFile = (content: string, filename: string): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "extend-validate-"));
+  const filePath = path.join(dir, filename);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+};
+
+const cleanupTempFile = (filePath: string): void => {
+  const dir = path.dirname(filePath);
+  fs.rmSync(dir, { recursive: true, force: true });
+};
+
+const validExtendedScript = JSON.stringify({
+  $mulmocast: { version: "1.1" },
+  speechParams: { speakers: {} },
+  imageParams: { provider: "openai", images: {} },
+  beats: [
+    {
+      text: "Hello world",
+      meta: {
+        tags: ["intro"],
+        section: "opening",
+        context: "Opening slide",
+        keywords: ["hello"],
+        expectedQuestions: ["What is this?"],
+      },
+    },
+    {
+      text: "Main content",
+      meta: {
+        tags: ["content"],
+        section: "main",
+        context: "Main section",
+      },
+    },
+  ],
+  scriptMeta: {
+    audience: "developers",
+    goals: ["Learn the basics"],
+    keywords: ["test"],
+    background: "A test presentation",
+  },
+  outputProfiles: {},
+});
+
+const validMinimalScript = JSON.stringify({
+  $mulmocast: { version: "1.1" },
+  speechParams: { speakers: {} },
+  imageParams: { provider: "openai", images: {} },
+  beats: [{ text: "slide 1" }],
+});
+
+const invalidScript = JSON.stringify({
+  beats: [{ text: "no mulmocast header" }],
+});
+
+test("extend validate: valid ExtendedScript passes", () => {
+  const filePath = createTempFile(validExtendedScript, "valid.json");
+  try {
+    const output = execSync(`${CLI} extend validate "${filePath}"`, { encoding: "utf-8" });
+    assert.ok(output.includes("Valid ExtendedScript"));
+    assert.ok(output.includes("Beats: 2"));
+    assert.ok(output.includes("ScriptMeta: yes"));
+    assert.ok(output.includes("Meta coverage: 100%"));
+    assert.ok(output.includes("opening"));
+    assert.ok(output.includes("main"));
+  } finally {
+    cleanupTempFile(filePath);
+  }
+});
+
+test("extend validate: valid minimal script passes", () => {
+  const filePath = createTempFile(validMinimalScript, "minimal.json");
+  try {
+    const output = execSync(`${CLI} extend validate "${filePath}"`, { encoding: "utf-8" });
+    assert.ok(output.includes("Valid ExtendedScript"));
+    assert.ok(output.includes("Beats: 1"));
+    assert.ok(output.includes("ScriptMeta: no"));
+    assert.ok(output.includes("Meta coverage: 0%"));
+  } finally {
+    cleanupTempFile(filePath);
+  }
+});
+
+test("extend validate: invalid script fails", () => {
+  const filePath = createTempFile(invalidScript, "invalid.json");
+  try {
+    assert.throws(
+      () => execSync(`${CLI} extend validate "${filePath}"`, { encoding: "utf-8" }),
+      (err: unknown) => {
+        const error = err as { stderr: string };
+        return error.stderr.includes("Validation failed");
+      }
+    );
+  } finally {
+    cleanupTempFile(filePath);
+  }
+});
+
+test("extend validate: non-existent file fails", () => {
+  assert.throws(
+    () => execSync(`${CLI} extend validate /tmp/does-not-exist.json`, { encoding: "utf-8" }),
+    (err: unknown) => {
+      const error = err as { stderr: string };
+      return error.stderr.includes("File not found");
+    }
+  );
+});
+
+test("extend validate: invalid JSON fails", () => {
+  const filePath = createTempFile("{ not valid json", "bad.json");
+  try {
+    assert.throws(
+      () => execSync(`${CLI} extend validate "${filePath}"`, { encoding: "utf-8" }),
+      (err: unknown) => {
+        const error = err as { stderr: string };
+        return error.stderr.includes("Failed to parse JSON");
+      }
+    );
+  } finally {
+    cleanupTempFile(filePath);
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,6 +731,14 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
+"@mulmocast/extended-types@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmocast/extended-types/-/extended-types-0.1.0.tgz#fc615728cd6698b84d84d73d4f4f4d4f09819d16"
+  integrity sha512-K+rJ1Eiea+geOVLmxtuJd+b+LMAq3D7BFFPtZ2POAPGpgjaK3Oe4qk7betnOIIMnGGNKqKuNU9PEXaPdNItZag==
+  dependencies:
+    mulmocast "^2.1.35"
+    zod "^4.3.6"
+
 "@napi-rs/canvas-android-arm64@0.1.80":
   version "0.1.80"
   resolved "https://registry.yarnpkg.com/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz#2779ca5c8aaeb46c85eb72d29f1eb34efd46fb45"


### PR DESCRIPTION
## Summary

- Add `mulmo-slide extend validate <file>` command to validate ExtendedScript JSON against the `@mulmocast/extended-types` schema
- Update `/extend` skill to run validation after generating output
- Add 5 tests covering valid, invalid, missing file, and bad JSON cases

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn test` - all 168 tests pass (5 new)
- [x] `yarn lint` clean
- [x] Manual: `yarn cli extend validate scripts/simple_text/extended_script.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)