### PR TITLE
fix: guard CLI prefix detection against missing package.json

### DIFF
--- a/.claude/skills/extend/SKILL.md
+++ b/.claude/skills/extend/SKILL.md
@@ -10,9 +10,10 @@ Convert a MulmoScript JSON into an ExtendedScript by adding `scriptMeta` and `be
 
 ## CLI Command
 
-Determine the correct CLI command prefix by checking `package.json` in the project root:
-- If `name` is `"@mulmocast/slide"` (i.e., developing MulmoCast-Slides itself) → use `yarn cli`
-- Otherwise → use `npx mulmo-slide`
+Determine the correct CLI command prefix:
+- If `package.json` exists in the project root and its `name` is `"@mulmocast/slide"` (i.e., developing MulmoCast-Slides itself) → use `yarn cli`
+- Otherwise (including when no `package.json` exists) → use `npx mulmo-slide`
+- NEVER create a `package.json` file for this purpose
 
 Use this prefix (referred to as `{cli}` below) for all CLI calls in the steps.
 

--- a/.claude/skills/narrate/SKILL.md
+++ b/.claude/skills/narrate/SKILL.md
@@ -12,9 +12,10 @@ Supported formats: `.pdf`, `.pptx`, `.md`, `.key`
 
 ## CLI Command
 
-Determine the correct CLI command prefix by checking `package.json` in the project root:
-- If `name` is `"@mulmocast/slide"` (i.e., developing MulmoCast-Slides itself) → use `yarn cli`
-- Otherwise → use `npx mulmo-slide`
+Determine the correct CLI command prefix:
+- If `package.json` exists in the project root and its `name` is `"@mulmocast/slide"` (i.e., developing MulmoCast-Slides itself) → use `yarn cli`
+- Otherwise (including when no `package.json` exists) → use `npx mulmo-slide`
+- NEVER create a `package.json` file for this purpose
 
 Use this prefix (referred to as `{cli}` below) for all CLI calls in the steps.
 


### PR DESCRIPTION
## Summary
- SKILL.md files now check if `package.json` exists before reading it
- Prevents Claude Code from creating a `package.json` when one doesn't exist
- Default is `npx mulmo-slide` when no `package.json` is found

🤖 Generated with [Claude Code](https://claude.com/claude-code)