### PR TITLE
chore: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![npm version](https://badge.fury.io/js/%40mulmocast%2Fslide.svg)](https://badge.fury.io/js/%40mulmocast%2Fslide)
 # MulmoCast-Slides
 
 A collection of tools to convert presentation files into MulmoScript format, enabling automated narration and processing of slide decks.


### PR DESCRIPTION
Add npm version badge for `@mulmocast/slide` package using badge.fury.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added npm version badge to README.
  * Cleaned up license section formatting in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->