### PR TITLE
docs: add Markdown to narrated video tutorials (JA/EN)

### DIFF
--- a/docs/tutorial-md-to-video-en.md
+++ b/docs/tutorial-md-to-video-en.md
@@ -1,0 +1,224 @@
+# Tutorial: Markdown to Narrated Video
+
+This tutorial walks you through converting a Markdown document (e.g., technical docs, blog posts, specifications) into a narrated video with AI-designed structure and speech. You'll also learn how to interactively query the content.
+
+## Prerequisites
+
+- Node.js 20+
+- [Claude Code](https://claude.com/claude-code) (for the `/md-to-mulmo` skill)
+- OpenAI API key (`OPENAI_API_KEY` environment variable)
+
+```bash
+# Install MulmoCast-Slides
+npm install -g @mulmocast/slide
+
+# Verify installation
+mulmo-slide --help
+```
+
+## Setup
+
+### 1. Create a project directory
+
+```bash
+mkdir my-md-project
+cd my-md-project
+```
+
+### 2. Configure API keys
+
+Create a `.env` file with your API key:
+
+```bash
+cat <<'EOF' > .env
+OPENAI_API_KEY=sk-your-openai-api-key
+EOF
+```
+
+- `OPENAI_API_KEY`: Used for text-to-speech (TTS) and video generation
+
+### 3. Place your Markdown file
+
+Copy the Markdown you want to convert into the project directory:
+
+```bash
+cp /path/to/your-document.md .
+```
+
+### 4. Install Claude Code skills
+
+```bash
+mulmo-slide extend init
+```
+
+This copies the skill files to `.claude/skills/` in your project.
+
+## Quick Start (Copy-Paste)
+
+```bash
+# In Claude Code, run:
+/md-to-mulmo your-document.md
+```
+
+That's it! The `/md-to-mulmo` skill automatically:
+1. Parses the Markdown structure (`parse-md`)
+2. Extracts sections, headings, code blocks, etc.
+3. Uses an LLM to design a presentation plan
+4. Assembles the ExtendedScript (`assemble-extended`)
+5. Generates `detailed` (full) and `short` (summary) output profiles
+
+## What `/md-to-mulmo` Produces
+
+```
+scripts/your-document/
+  parsed_structure.json           # Parsed Markdown structure
+  extended-script.schema.json     # ExtendedScript schema
+  presentation-plan.schema.json   # Presentation plan schema
+  presentation_plan.json          # LLM-designed presentation plan
+  extended_script.json            # ExtendedScript (narration + metadata)
+```
+
+## After `/md-to-mulmo`: Next Steps
+
+### Query the Content Interactively
+
+Ask questions about your document:
+
+```bash
+npx mulmocast-preprocessor query scripts/your-document/extended_script.json -i
+```
+
+Example session:
+```
+> What is the main topic of this document?
+The document explains microservice architecture design patterns...
+
+> What deployment strategies are recommended?
+1. Blue-Green Deployment
+2. Canary Release
+3. Rolling Update
+
+> exit
+```
+
+Ask a single question:
+```bash
+npx mulmocast-preprocessor query scripts/your-document/extended_script.json "What are the key points?"
+```
+
+Generate a summary:
+```bash
+npx mulmocast-preprocessor summarize scripts/your-document/extended_script.json
+```
+
+### Generate a Narrated Video
+
+Convert the ExtendedScript to a clean MulmoScript, then generate the video:
+
+```bash
+npx mulmocast-preprocessor scripts/your-document/extended_script.json \
+  -o scripts/your-document/your-document.json
+npx mulmo movie scripts/your-document/your-document.json
+```
+
+Output: `output/your-document_ja.mp4`
+
+### Output Profiles
+
+The ExtendedScript includes two output profiles:
+
+- **`detailed`**: Full version with all beats
+- **`short`**: Summary version with core beats only
+
+Use the preprocessor's `-p` option to switch profiles:
+
+```bash
+# Generate with the short profile
+npx mulmocast-preprocessor scripts/your-document/extended_script.json \
+  -o scripts/your-document/your-document.json -p short
+```
+
+### Review and Iterate
+
+Watch the video and check the narration quality. If you want to adjust:
+
+1. Edit `scripts/your-document/extended_script.json` directly (modify `text` fields)
+2. Or re-run `/md-to-mulmo` with instructions for adjustments
+3. Re-run the video generation commands above
+
+## Pipeline Details (Manual Execution)
+
+You can also run each step of `/md-to-mulmo` individually:
+
+### Step 1: Parse Markdown
+
+```bash
+mulmo-slide parse-md your-document.md
+```
+
+Parses the Markdown structure (headings, paragraphs, code blocks, lists, etc.) and generates JSON and JSON Schema files.
+
+### Step 2: Create Presentation Plan (LLM)
+
+```bash
+# In Claude Code, run:
+/md-to-mulmo your-document.md
+```
+
+The LLM designs a presentation plan (`presentation_plan.json`) based on `parsed_structure.json`.
+
+### Step 3: Assemble ExtendedScript
+
+```bash
+mulmo-slide assemble-extended scripts/your-document/presentation_plan.json
+```
+
+Generates the ExtendedScript from the presentation plan.
+
+### Step 4: Convert to MulmoScript
+
+```bash
+npx mulmocast-preprocessor scripts/your-document/extended_script.json \
+  -o scripts/your-document/your-document.json
+```
+
+### Step 5: Generate Video
+
+```bash
+npx mulmo movie scripts/your-document/your-document.json
+```
+
+Output: `output/your-document_ja.mp4`
+
+## Alternative Workflow: `/narrate`
+
+If you already have a slide-format presentation (PDF, PPTX, Keynote), you can use the `/narrate` skill instead. See the [PDF to Narrated Video tutorial](./tutorial-pdf-to-video-en.md) for details.
+
+## Troubleshooting
+
+### `mulmo-slide extend init` not run
+
+If the `/md-to-mulmo` skill is not found, run `mulmo-slide extend init` to install the skills.
+
+### File not found with `parse-md`
+
+Verify the Markdown file path is correct. Both relative and absolute paths are accepted.
+
+### Validation error with `assemble-extended`
+
+Ensure `presentation_plan.json` conforms to `presentation-plan.schema.json`. If the LLM-generated plan has an invalid format, re-run `/md-to-mulmo`.
+
+### "Unrecognized key: scriptMeta" error when running `mulmo movie`
+
+The preprocessor may not fully strip extended fields. Run this to clean up:
+
+```bash
+node -e "
+const fs = require('fs');
+const d = JSON.parse(fs.readFileSync('scripts/your-document/your-document.json', 'utf8'));
+delete d.scriptMeta;
+delete d.outputProfiles;
+d.beats.forEach(b => { delete b.meta; delete b.variants; });
+fs.writeFileSync('scripts/your-document/your-document.json', JSON.stringify(d, null, 2));
+"
+```

--- a/docs/tutorial-md-to-video-ja.md
+++ b/docs/tutorial-md-to-video-ja.md
@@ -1,0 +1,224 @@
+# チュートリアル: Markdown からナレーション付き動画を作成する
+
+Markdown ドキュメント（技術文書、ブログ記事、仕様書など）を、AI が構成を設計しナレーションを付けた動画に変換する手順です。作成した ExtendedScript に対して、対話的に質問することもできます。
+
+## 事前準備
+
+- Node.js 20 以上
+- [Claude Code](https://claude.com/claude-code)（`/md-to-mulmo` スキルで使用）
+- OpenAI API キー（環境変数 `OPENAI_API_KEY`）
+
+```bash
+# MulmoCast-Slides をインストール
+npm install -g @mulmocast/slide
+
+# インストール確認
+mulmo-slide --help
+```
+
+## セットアップ
+
+### 1. プロジェクトディレクトリを作成
+
+```bash
+mkdir my-md-project
+cd my-md-project
+```
+
+### 2. API キーを設定
+
+`.env` ファイルを作成して API キーを記述します：
+
+```bash
+cat <<'EOF' > .env
+OPENAI_API_KEY=sk-your-openai-api-key
+EOF
+```
+
+- `OPENAI_API_KEY`: 音声合成（TTS）と動画生成に使用
+
+### 3. Markdown ファイルを配置
+
+変換したい Markdown をプロジェクトディレクトリにコピーします：
+
+```bash
+cp /path/to/your-document.md .
+```
+
+### 4. Claude Code スキルをインストール
+
+```bash
+mulmo-slide extend init
+```
+
+これで `.claude/skills/` にスキルファイルがコピーされます。
+
+## クイックスタート（コピペで実行）
+
+```bash
+# Claude Code 内で実行:
+/md-to-mulmo your-document.md
+```
+
+これだけです！ `/md-to-mulmo` スキルが自動的に：
+1. Markdown の構造を解析（`parse-md`）
+2. セクション・見出し・コードブロック等を抽出
+3. LLM がプレゼンテーションプランを設計
+4. ExtendedScript を組み立て（`assemble-extended`）
+5. `detailed`（完全版）と `short`（要約版）の出力プロファイルを生成
+
+## `/md-to-mulmo` が生成するもの
+
+```
+scripts/your-document/
+  parsed_structure.json           # Markdown のパース結果
+  extended-script.schema.json     # ExtendedScript のスキーマ
+  presentation-plan.schema.json   # プレゼンプランのスキーマ
+  presentation_plan.json          # LLM が作成したプレゼンプラン
+  extended_script.json            # ExtendedScript（ナレーション + メタデータ）
+```
+
+## `/md-to-mulmo` 後の次のステップ
+
+### 内容に対話的に質問する
+
+ドキュメントについて質問できます：
+
+```bash
+npx mulmocast-preprocessor query scripts/your-document/extended_script.json -i
+```
+
+実行例：
+```
+> このドキュメントの主題は何ですか？
+マイクロサービスアーキテクチャの設計パターンについて解説しています...
+
+> 推奨されるデプロイ戦略は？
+1. Blue-Green デプロイメント
+2. カナリアリリース
+3. ローリングアップデート
+
+> exit
+```
+
+一つの質問だけ聞く：
+```bash
+npx mulmocast-preprocessor query scripts/your-document/extended_script.json "主なポイントは何ですか？"
+```
+
+要約を生成する：
+```bash
+npx mulmocast-preprocessor summarize scripts/your-document/extended_script.json -l ja
+```
+
+### ナレーション付き動画を生成する
+
+ExtendedScript をクリーンな MulmoScript に変換してから動画を生成します：
+
+```bash
+npx mulmocast-preprocessor scripts/your-document/extended_script.json \
+  -o scripts/your-document/your-document.json
+npx mulmo movie scripts/your-document/your-document.json
+```
+
+出力: `output/your-document_ja.mp4`
+
+### 出力プロファイル
+
+ExtendedScript には 2 つの出力プロファイルが含まれます：
+
+- **`detailed`**: すべてのビートを含む完全版
+- **`short`**: コアビートのみの要約版
+
+preprocessor の `-p` オプションでプロファイルを切り替えられます：
+
+```bash
+# 要約版で生成
+npx mulmocast-preprocessor scripts/your-document/extended_script.json \
+  -o scripts/your-document/your-document.json -p short
+```
+
+### レビューと改善
+
+動画を視聴してナレーションの品質を確認します。調整したい場合は：
+
+1. `scripts/your-document/extended_script.json` の `text` フィールドを直接編集する
+2. または `/md-to-mulmo` を再実行して調整を依頼する
+3. 上記の動画生成コマンドを再実行する
+
+## パイプラインの詳細（手動実行）
+
+`/md-to-mulmo` の各ステップを個別に実行することもできます：
+
+### Step 1: Markdown パース
+
+```bash
+mulmo-slide parse-md your-document.md
+```
+
+Markdown の構造（見出し、段落、コードブロック、リスト等）を解析し、JSON と JSON Schema を生成します。
+
+### Step 2: プレゼンテーションプラン作成（LLM）
+
+```bash
+# Claude Code 内で実行:
+/md-to-mulmo your-document.md
+```
+
+LLM が `parsed_structure.json` を基にプレゼンプラン（`presentation_plan.json`）を設計します。
+
+### Step 3: ExtendedScript 組み立て
+
+```bash
+mulmo-slide assemble-extended scripts/your-document/presentation_plan.json
+```
+
+プレゼンプランから ExtendedScript を生成します。
+
+### Step 4: MulmoScript 変換
+
+```bash
+npx mulmocast-preprocessor scripts/your-document/extended_script.json \
+  -o scripts/your-document/your-document.json
+```
+
+### Step 5: 動画生成
+
+```bash
+npx mulmo movie scripts/your-document/your-document.json
+```
+
+出力: `output/your-document_ja.mp4`
+
+## 代替ワークフロー: `/narrate`
+
+既にスライド形式のプレゼンテーション（PDF、PPTX、Keynote）がある場合は、`/narrate` スキルも利用できます。詳しくは[PDF からナレーション付き動画を作成するチュートリアル](./tutorial-pdf-to-video-ja.md)をご覧ください。
+
+## トラブルシューティング
+
+### `mulmo-slide extend init` を実行していない
+
+`/md-to-mulmo` スキルが見つからない場合は、`mulmo-slide extend init` を実行してスキルをインストールしてください。
+
+### `parse-md` でファイルが見つからない
+
+Markdown ファイルのパスが正しいか確認してください。相対パスまたは絶対パスのどちらでも指定できます。
+
+### `assemble-extended` でバリデーションエラー
+
+`presentation_plan.json` が `presentation-plan.schema.json` に準拠しているか確認してください。LLM が生成したプランのフォーマットが不正な場合は、`/md-to-mulmo` を再実行してください。
+
+### `mulmo movie` で "Unrecognized key: scriptMeta" エラー
+
+preprocessor がメタデータを完全に除去できない場合があります。以下で手動クリーンアップできます：
+
+```bash
+node -e "
+const fs = require('fs');
+const d = JSON.parse(fs.readFileSync('scripts/your-document/your-document.json', 'utf8'));
+delete d.scriptMeta;
+delete d.outputProfiles;
+d.beats.forEach(b => { delete b.meta; delete b.variants; });
+fs.writeFileSync('scripts/your-document/your-document.json', JSON.stringify(d, null, 2));
+"
+```


### PR DESCRIPTION
## Summary

- Add `docs/tutorial-md-to-video-ja.md` (Japanese) and `docs/tutorial-md-to-video-en.md` (English)
- Covers the `/md-to-mulmo` workflow: Markdown → ExtendedScript → narrated video
- Includes quick start, manual pipeline steps (parse-md → LLM plan → assemble-extended → preprocessor → movie), output profiles (detailed/short), interactive queries, and troubleshooting
- Structure and tone match the existing PDF-to-video tutorials

## User Prompt

- 既存の `docs/tutorial-pdf-to-video-ja.md` / `docs/tutorial-pdf-to-video-en.md` に倣い、Markdown ドキュメントから ExtendedScript を経由してナレーション付き動画を生成するワークフローのチュートリアルを作成する。`npx mulmocast-preprocessor query` の対話モードも含む。

## Test plan

- [ ] Verify all CLI commands referenced in tutorials exist (`mulmo-slide parse-md`, `mulmo-slide assemble-extended`, `mulmo-slide extend init`)
- [ ] Verify file path conventions match actual output (`scripts/{basename}/parsed_structure.json`, etc.)
- [ ] Confirm structure consistency with existing PDF tutorials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive English tutorial for converting Markdown files to narrated video, including prerequisites, setup instructions, step-by-step pipeline, and troubleshooting guidance.
  * Added Japanese tutorial providing the same comprehensive documentation for Japanese-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->