### PR TITLE
fix: unify dotenv import style

### DIFF
--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -18,7 +18,7 @@ import {
 import { findBundles, getMimeType, isValidFile, createFileStream } from "../utils/bundle-server.js";
 
 // Load .env file
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const DEFAULT_PORT = 3000;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import dotenv from "dotenv";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { convertMarp } from "./convert/marp.js";
@@ -270,8 +271,7 @@ async function runAction(
 }
 
 async function runUpload(basename: string) {
-  const dotenv = await import("dotenv");
-  dotenv.config();
+  dotenv.config({ quiet: true });
 
   const apiKey = process.env.MULMO_MEDIA_API_KEY;
   if (!apiKey) {

--- a/src/convert/movie.ts
+++ b/src/convert/movie.ts
@@ -1,3 +1,4 @@
+import dotenv from "dotenv";
 import * as fs from "fs";
 import * as path from "path";
 import { execSync, spawn } from "child_process";
@@ -435,8 +436,7 @@ export async function convertMovie(options: ConvertMovieOptions): Promise<Conver
 
 async function main() {
   // Load environment variables
-  const dotenv = await import("dotenv");
-  dotenv.config();
+  dotenv.config({ quiet: true });
 
   const argv = await yargs(hideBin(process.argv))
     .usage("Usage: $0 <video-file> [options]")


### PR DESCRIPTION
## Summary
- Unify all `dotenv` imports to top-level `import dotenv from "dotenv"` (eliminate `await import("dotenv")` pattern)
- Unify all `dotenv.config()` calls to use `{ quiet: true }` option, matching the style in `src/actions/upload.ts`

## Changed files
- `src/cli.ts` — `await import("dotenv")` → top-level import, add `{ quiet: true }`
- `src/convert/movie.ts` — `await import("dotenv")` → top-level import, add `{ quiet: true }`
- `src/actions/preview.ts` — add `{ quiet: true }`

## User Prompt
- dotenvについて、いろいろな書き方がある。src/actions/upload.tsでのquietを使った書き方に統一して
- `import dotenv from "dotenv"` にも統一。await importを途中でさせない

## Test plan
- [x] `yarn lint` passes
- [x] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced non-critical startup messages during environment variable initialization to provide a cleaner startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->