### PR TITLE
Fix Vite dev server: non-ASCII bundle paths and Safari video playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "dotenv": "^17.3.1",
     "franc": "^6.2.0",
     "mulmocast": "2.2.0",
-    "mulmocast-viewer": "^0.2.3",
+    "mulmocast-viewer": "^0.2.4",
     "node-pptx-parser": "^1.0.1",
     "openai": "^6.22.0",
     "pdf-parse": "^2.4.5",

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -140,7 +140,12 @@ export function startPreviewServer(port: number = DEFAULT_PORT): void {
     // Serve bundle files from output/
     if (pathname.startsWith("/bundles/")) {
       const bundlePath = pathname.slice("/bundles/".length);
-      const filePath = path.join(outputDir, bundlePath);
+      const filePath = path.normalize(path.join(outputDir, bundlePath));
+      if (!filePath.startsWith(outputDir + path.sep) && filePath !== outputDir) {
+        res.writeHead(403, { "Content-Type": "text/plain" });
+        res.end("Forbidden");
+        return;
+      }
       serveFile(req, res, filePath);
       return;
     }

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -93,7 +93,14 @@ export function startPreviewServer(port: number = DEFAULT_PORT): void {
 
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || "/", `http://localhost:${port}`);
-    const pathname = decodeURIComponent(url.pathname);
+    let pathname: string;
+    try {
+      pathname = decodeURIComponent(url.pathname);
+    } catch {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Bad Request");
+      return;
+    }
 
     // API endpoint for bundles list
     if (pathname === "/api/bundles") {

--- a/src/vue/App.vue
+++ b/src/vue/App.vue
@@ -565,6 +565,7 @@ function discardRecordings() {
             :init-page="currentPage"
             v-model:audio-lang="audioLang"
             v-model:text-lang="textLang"
+            media-aspect-ratio="video"
             @updated-page="onUpdatedPage"
           />
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,7 +74,14 @@ function bundleServerPlugin() {
 
       // Serve bundle files from output/
       server.middlewares.use("/bundles", (req: any, res: any, next: any) => {
-        let urlPath = decodeURIComponent(req.url?.split("?")[0] || "");
+        let urlPath: string;
+        try {
+          urlPath = decodeURIComponent(req.url?.split("?")[0] || "");
+        } catch {
+          res.statusCode = 400;
+          res.end("Bad Request");
+          return;
+        }
         // Strip /bundles prefix if present (depends on how Vite routes the request)
         if (urlPath.startsWith("/bundles/")) {
           urlPath = urlPath.slice("/bundles".length);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,7 +73,7 @@ function bundleServerPlugin() {
 
       // Serve bundle files from output/
       server.middlewares.use("/bundles", (req: any, res: any, next: any) => {
-        let urlPath = req.url?.split("?")[0] || "";
+        let urlPath = decodeURIComponent(req.url?.split("?")[0] || "");
         // Strip /bundles prefix if present (depends on how Vite routes the request)
         if (urlPath.startsWith("/bundles/")) {
           urlPath = urlPath.slice("/bundles".length);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,7 +79,12 @@ function bundleServerPlugin() {
         if (urlPath.startsWith("/bundles/")) {
           urlPath = urlPath.slice("/bundles".length);
         }
-        const filePath = path.join(outputDir, urlPath);
+        const filePath = path.normalize(path.join(outputDir, urlPath));
+        if (!filePath.startsWith(outputDir + path.sep) && filePath !== outputDir) {
+          res.statusCode = 403;
+          res.end("Forbidden");
+          return;
+        }
 
         if (isValidFile(filePath)) {
           const stat = fs.statSync(filePath);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
+import * as fs from "fs";
 import * as path from "path";
 import dotenv from "dotenv";
 import { saveBeatText, transcribeAudio, parseRequestBody } from "./src/utils/audio-save";
@@ -81,8 +82,40 @@ function bundleServerPlugin() {
         const filePath = path.join(outputDir, urlPath);
 
         if (isValidFile(filePath)) {
-          res.setHeader("Content-Type", getMimeType(filePath));
-          createFileStream(filePath).pipe(res);
+          const stat = fs.statSync(filePath);
+          const fileSize = stat.size;
+          const mimeType = getMimeType(filePath);
+          const range = req.headers.range;
+
+          if (range) {
+            const match = range.match(/bytes=(\d+)-(\d*)/);
+            if (!match) {
+              res.statusCode = 416;
+              res.setHeader("Content-Range", `bytes */${fileSize}`);
+              res.end();
+              return;
+            }
+            const start = parseInt(match[1], 10);
+            const rawEnd = match[2] ? parseInt(match[2], 10) : fileSize - 1;
+            if (start >= fileSize || start > rawEnd) {
+              res.statusCode = 416;
+              res.setHeader("Content-Range", `bytes */${fileSize}`);
+              res.end();
+              return;
+            }
+            const end = Math.min(rawEnd, fileSize - 1);
+            res.statusCode = 206;
+            res.setHeader("Content-Type", mimeType);
+            res.setHeader("Content-Range", `bytes ${start}-${end}/${fileSize}`);
+            res.setHeader("Accept-Ranges", "bytes");
+            res.setHeader("Content-Length", String(end - start + 1));
+            fs.createReadStream(filePath, { start, end }).pipe(res);
+          } else {
+            res.setHeader("Content-Type", mimeType);
+            res.setHeader("Accept-Ranges", "bytes");
+            res.setHeader("Content-Length", String(fileSize));
+            createFileStream(filePath).pipe(res);
+          }
         } else {
           next();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,17 +738,17 @@
     "@mulmocast/extended-types" "^0.3.0"
     "@mulmocast/types" "^2.1.38"
 
-"@mulmocast/types@2.1.36":
-  version "2.1.36"
-  resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.1.36.tgz#21fa83289fbc8bb60cd1bdbe3905f43b09bb3eff"
-  integrity sha512-ftr+hKgZHmGNQUhd7yVxGyOZwWe3/KA251tWfe5lxjcEeZV4tAlUA1C8p3zd4Qp32Jp2cjHwGUvZi7PEJrv4qw==
-  dependencies:
-    zod "^4.3.5"
-
 "@mulmocast/types@2.2.0", "@mulmocast/types@^2.1.38":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.2.0.tgz#fa6b3a8ad150468506bf8ca259e47d689a8a31fe"
   integrity sha512-PMbnNeLepkVE4ZQfzJY4CKYe+lf72FBPVR61V6n+KXcRV6UBOdKXHjbjdoeE7DZN+YO9AJFsv43qSCC4i0u/+A==
+  dependencies:
+    zod "^4.3.5"
+
+"@mulmocast/types@2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.6.5.tgz#20a291ffc5050bb5c0c237a571ecefc8b750a9c5"
+  integrity sha512-ldJJfTf/kAVgYUL5r9dQGUtM15JTivU0kxQLnwlk78bHU4x2ALVeyFf/4L7CN4/ti8gR9XH87wX87rOhRr2+OQ==
   dependencies:
     zod "^4.3.5"
 
@@ -3676,12 +3676,12 @@ ms@^2.0.0, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mulmocast-viewer@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/mulmocast-viewer/-/mulmocast-viewer-0.2.3.tgz#4e8dd77e37bbaf302caf2c6d2dd5f24c000a2dcd"
-  integrity sha512-PZapgOnXdZmaHxHlR1Z11vgQ6XMZFAG6vvB9zgT2M0THsMnG/0PpTkQ8RY/QG5r891jtbceu75zY7et+B1CqSw==
+mulmocast-viewer@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/mulmocast-viewer/-/mulmocast-viewer-0.2.4.tgz#6ee368fd6912cc3fc299d227af0127a2df4920e7"
+  integrity sha512-AP3SDRB7ZyJbAut26pAhXC4pdxuzJMwdnrz9zO5Wyh4fMsYSYybtrRhiNAC8zP4vuLSIfGA1w3vLU73imh+LFg==
   dependencies:
-    "@mulmocast/types" "2.1.36"
+    "@mulmocast/types" "2.6.5"
 
 mulmocast-vision@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
## 概要

Vite dev server (`yarn dev`) で以下の2つの問題を修正:

1. 日本語名バンドルの `mulmo_view.json` が読み込めない
2. Safari で動画（mp4）が再生できない

## 変更内容

### 1. 非 ASCII パスの URL デコード

`/bundles` ミドルウェアで `req.url` を `decodeURIComponent` していなかったため、日本語名のバンドルへのリクエストがファイルにマッチせず、SPA フォールバックで `index.html` が JSON として返されていた。

### 2. Range リクエスト対応（Safari）

Safari は動画/音声ファイルの再生に HTTP Range リクエストを要求する。ミドルウェアがファイル全体をストリーミングするだけだったため、mp4 の再生に失敗していた。`preview.ts` と同様の Range 対応を追加。

### 3. mulmocast-viewer 0.2.4 へのアップグレード

beat 遷移時のレイアウトシフト防止のため `media-aspect-ratio="video"` を有効化（receptron/mulmocast-viewer#46 に対応）。

## 動作確認

- [x] Chromium（Playwright）で日本語名バンドルの表示を確認
- [x] Safari で日本語名バンドルの動画再生を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable video aspect ratio for media display.
  * Improved media streaming with HTTP byte-range support (better seeking/resume).

* **Bug Fixes / Security**
  * Hardened static file serving to reject malformed requests and prevent path traversal.

* **Chores**
  * Updated mulmocast-viewer dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->