### PR TITLE
chore: bump actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
         run: yarn cli pdf samples/20251008_2.pdf
 
       - name: Upload generated scripts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generated-scripts-${{ matrix.os }}
           path: scripts/


### PR DESCRIPTION
## Summary
Bumps `actions/upload-artifact` from `@v4` to `@v7` (current latest) in `.github/workflows/pull_request.yaml`.

## Items to Confirm / Review
- Mechanical version bump only. CI run on this PR validates the artifact upload step still works under v7.

## User Prompt
`actions/upload-artifact@v4` を最新（v7）にバージョンアップ。`~/ss/llm` 配下の重複しない自リポ + GUIChatPlugins 配下を対象に、main を最新化してから新ブランチで実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
