### PR TITLE
chore: bump GitHub Actions to latest + Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Mechanical bump of GitHub Actions to current latest and (where applicable) extend Node matrix to include 24.x. See commit message for details. Auto-generated across receptron/* + isamu/* source repos. CI on this PR is the verification.